### PR TITLE
Add GCS download button

### DIFF
--- a/src/AppInterface.tsx
+++ b/src/AppInterface.tsx
@@ -272,7 +272,12 @@ const PassFiles: React.FC<PassFilesProps> = ({
                       Download
                     </a>
                     <a
-                      href={`https://storage.cloud.google.com/viam-data-${organizationId}/${organizationId}/${machineId}/${partId}/files/${file.metadata?.binaryDataId.split("/").pop()}${file.metadata?.fileName}.gz`}
+                      href={
+                        `https://storage.cloud.google.com/viam-data-${organizationId}/` +
+                        `${organizationId}/${machineId}/${partId}/files/` +
+                        `${file.metadata?.binaryDataId.split("/").pop()}` +
+                        `${file.metadata?.fileName}.gz`
+                      }
                       target="_blank"
                       style={{
                         marginLeft: '12px',


### PR DESCRIPTION
Until we update our internal file handler to proxy to GCS (or whatever other method we go with), this PR adds a button that will download a file directly from GCS.

Should work in most cases. Might be some edge cases that I haven't considered, but thought it would be better than nothing.

Users must have a Viam email and have access to GCS (when you click the button, if you are not already logged into Google Cloud, it will prompt you to do so).

<img width="352" height="228" alt="Screenshot 2025-12-12 at 7 36 45 PM" src="https://github.com/user-attachments/assets/30af4a23-f6a5-4b7b-9fc1-5fb828a184f4" />