### PR TITLE
Increase error message character limit from 150 to 200

### DIFF
--- a/src/AppInterface.tsx
+++ b/src/AppInterface.tsx
@@ -1098,12 +1098,12 @@ const AppInterface: React.FC<AppViewProps> = ({
                                       >
                                         {expandedErrors.has(pass.pass_id) 
                                           ? pass.err_string 
-                                          : pass.err_string.length > 150 
-                                            ? `${pass.err_string.substring(0, 150)}...` 
+                                          : pass.err_string.length > 200 
+                                            ? `${pass.err_string.substring(0, 200)}...` 
                                             : pass.err_string
                                         }
                                       </span>
-                                      {pass.err_string.length > 150 && (
+                                      {pass.err_string.length > 200 && (
                                         <button
                                           onClick={(e) => {
                                             e.stopPropagation();

--- a/src/components/HistoryTable/index.tsx
+++ b/src/components/HistoryTable/index.tsx
@@ -662,12 +662,12 @@ const HistoryTable: React.FC<HistoryTableProps> = ({
                                       >
                                         {expandedErrors.has(pass.pass_id) 
                                           ? pass.err_string 
-                                          : pass.err_string.length > 150 
-                                            ? `${pass.err_string.substring(0, 150)}...` 
+                                          : pass.err_string.length > 200 
+                                            ? `${pass.err_string.substring(0, 200)}...` 
                                             : pass.err_string
                                         }
                                       </span>
-                                      {pass.err_string.length > 150 && (
+                                      {pass.err_string.length > 200 && (
                                         <button
                                           onClick={(e) => {
                                             e.stopPropagation();


### PR DESCRIPTION
This change increases the error message display limit from 150 to 200 characters. Currently it truncates common error messages like p-stops and cancellations just shy of the important information.

<img width="629" height="69" alt="image" src="https://github.com/user-attachments/assets/dff4835e-0ca9-4670-9013-699352bdfaf0" />

<img width="651" height="91" alt="image" src="https://github.com/user-attachments/assets/a7bbe2f3-9838-4b63-a6d5-5ec1165b82f4" />
