### PR TITLE
feat: improve rollback tag mechanism

### DIFF
--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -23,19 +23,18 @@ jobs:
         id: rollback
         run: |
           git fetch --tags
+          PACKAGE_VERSION=$(node -p "require('./package.json').version")
           COMMIT=$(git rev-list -n 1 "${{ inputs.rollback_tag }}")
           echo "commit=$COMMIT" >> $GITHUB_OUTPUT
+          echo "package_version=$PACKAGE_VERSION" >> $GITHUB_OUTPUT
 
       - name: Determine next patch version
         id: version
         run: |
-          LATEST_TAG=$(git tag --sort=-v:refname | head -n 1)
-          echo "Latest tag: $LATEST_TAG"
-
-          IFS='.' read -r MAJOR MINOR PATCH <<< "$LATEST_TAG"
+          IFS='.' read -r MAJOR MINOR PATCH <<< "${{ steps.rollback.outputs.package_version }}"
           NEXT_PATCH=$((PATCH + 1))
-
-          NEW_TAG="$MAJOR.$MINOR.$NEXT_PATCH"
+          NEW_TAG_VERSION="$MAJOR.$MINOR.$NEXT_PATCH"
+          NEW_TAG="${NEW_TAG_VERSION}-rollback-${{inputs.rollback_tag}}-$(date +%Y%m%d%H%M%S)"
           echo "new_tag=$NEW_TAG" >> $GITHUB_OUTPUT
 
       - name: Create rollback tag


### PR DESCRIPTION
# Description
Previously, the rollback mechanism would grab the latest release tag and create a new tag like `{major}.{minor}.{patch++}` this would cause the tag to get out of sync with the package.json version when rollbacks are preformed requiring manual updating of the package.json.

This PR changes the rollback tag mechanism to use the package json for the source of truth and create a tag of the form `{major}.{minor}.{patch++}-rollback-{desired_tag}-{datetime}`

this allows changesets to successfully update the package json without conflict since the rollback alpha tag will not conflict with the package.json changeset made one anymore.

# Testing

tested in a viam-skeleton app, ensured tags were created properly https://github.com/mattmacf98/viam-app-skeleton/tags and releases made it to the viam registry https://app.viam.com/module/mattmacf/viam-app-skeleton