### PR TITLE
do not early return pass file updating on empty snapshot predicate

### DIFF
--- a/.changeset/dirty-keys-fix.md
+++ b/.changeset/dirty-keys-fix.md
@@ -1,0 +1,5 @@
+---
+'sanding-monitoring-web-app': patch
+---
+
+do not early return file updates on empty snapshots predicate

--- a/src/lib/contexts/SinglePassContext.tsx
+++ b/src/lib/contexts/SinglePassContext.tsx
@@ -168,9 +168,9 @@ export function SinglePassProvider({
         const newSnapshots = nextFiles.filter((file) =>
           file.fileName.includes(SNAPSHOT_FILE_NAME_PREFIX)
         )
-        if (newSnapshots.length === 0) return
-
-        setSnapshots((prev) => deduplicateFiles(prev, newSnapshots))
+        if (newSnapshots.length !== 0) {
+          setSnapshots((prev) => deduplicateFiles(prev, newSnapshots))
+        }
         setPassFiles((prev) => deduplicateFiles(prev, nextFiles))
       },
       controller.signal


### PR DESCRIPTION
## Description

We saw a bug here [APP-15355](https://viam.atlassian.net/browse/APP-15355) where some files were not searchable in the SHW app, this PR fixes a bug where we would stop updating all files based on the presence of new snapshot files.

## Testing

I updated my local and confirmed the full set of retrieved files is now updated on the ui

https://github.com/user-attachments/assets/a1e0de16-e0f3-4d45-9f54-46b11d5dc00b


## Mental Checklist

- [N/A] I used tailwind styling
- [N/A] I split my code into components where possible
- [N/A] I used contexts instead of drilling props down the component tree
- [YES] I deployed the change to my personal module [link](https://sanding-monitoring-web-app_mattmacf.viamapplications.com/machine/njsanding1-main.tbr1ap8x6t.viam.cloud/#/passes/3f02891ae69fc5714d95350996657400)