### PR TITLE
Use current_state field as primary status signal in StatusBadge

### DIFF
--- a/.changeset/bumpy-turtles-clap.md
+++ b/.changeset/bumpy-turtles-clap.md
@@ -1,0 +1,5 @@
+---
+'sanding-monitoring-web-app': minor
+---
+
+Use current_state field as primary status signal in StatusBadge

--- a/src/SinglePassPage.tsx
+++ b/src/SinglePassPage.tsx
@@ -157,7 +157,7 @@ function SinglePassPage() {
         <div className="font-semibold text-zinc-900 text-sm">
           Pass {pass.pass_id.substring(0, 8)}
         </div>
-        <StatusBadge success={pass.success} />
+        <StatusBadge pass={pass} />
         <div className="text-sm text-zinc-600">
           {pass.start.toLocaleString()} – {pass.end.toLocaleTimeString()}
         </div>

--- a/src/components/HistoryTable/CollapsedRow.tsx
+++ b/src/components/HistoryTable/CollapsedRow.tsx
@@ -203,7 +203,7 @@ export const CollapsedRow = ({
         )}
       </td>
       <td>
-        <StatusBadge success={pass.success} />
+        <StatusBadge pass={pass} />
       </td>
       <td className="text-zinc-700">{pass.start.toLocaleTimeString()}</td>
       <td className="text-zinc-700">{pass.end.toLocaleTimeString()}</td>

--- a/src/components/StatusBadge.tsx
+++ b/src/components/StatusBadge.tsx
@@ -1,15 +1,32 @@
-export const StatusBadge = (props: { success: boolean }) => {
-  if (props.success) {
-    return (
-      <span className="moveleft inline-flex items-center justify-center py-1 rounded-full text-xs font-medium bg-green-100 text-green-800 status-badge-width">
-        Success
-      </span>
-    )
-  } else {
-    return (
-      <span className="moveleft inline-flex items-center justify-center py-1 rounded-full text-xs font-medium bg-red-100 text-red-800 status-badge-width">
-        Failed
-      </span>
-    )
+import { Pass } from '../lib/types'
+
+const getStatus = (pass: Pass): { label: string; className: string } => {
+  // Use current_state as the primary signal (set by backend on all new records)
+  if (pass.current_state) {
+    if (pass.current_state === 'Succeeded') {
+      return { label: 'Success', className: 'bg-green-100 text-green-800' }
+    }
+    if (pass.current_state === 'Failed') {
+      return { label: 'Failed', className: 'bg-red-100 text-red-800' }
+    }
+    // Any other state (e.g. Executing, GeneratingMesh) is in progress
+    return { label: pass.current_state, className: 'bg-blue-100 text-blue-800' }
   }
+
+  // Legacy fallback for records without current_state
+  if (pass.success) {
+    return { label: 'Success', className: 'bg-green-100 text-green-800' }
+  }
+  return { label: 'Failed', className: 'bg-red-100 text-red-800' }
+}
+
+export const StatusBadge = (props: { pass: Pass }) => {
+  const { label, className } = getStatus(props.pass)
+  return (
+    <span
+      className={`moveleft inline-flex items-center justify-center py-1 rounded-full text-xs font-medium status-badge-width ${className}`}
+    >
+      {label}
+    </span>
+  )
 }

--- a/src/lib/contexts/PassContext.tsx
+++ b/src/lib/contexts/PassContext.tsx
@@ -61,6 +61,10 @@ function processTabularDataToPasses(tabularData: any[]): Pass[] {
         pass.version != null
           ? Number(pass.version)
           : undefined,
+      current_state:
+        pass.current_state != null
+          ? String(pass.current_state)
+          : undefined,
     }
   })
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -23,6 +23,7 @@ export interface Pass {
   selected_num_rounds?: number
   piece_id?: string
   version?: number
+  current_state?: string
 }
 
 export interface PassNote {


### PR DESCRIPTION
## Description

The backend now publishes a `current_state` string on every pass summary record

This PR uses it as the primary status signal in the web app, replacing the binary `success` bool which caused incremental snapshots to display as "Failed"

## Testing
Don't think manual testing is strictly necessary