### PR TITLE
Add Cancelled badge to StatusBadge

### DIFF
--- a/.changeset/floppy-heads-sing.md
+++ b/.changeset/floppy-heads-sing.md
@@ -1,0 +1,5 @@
+---
+'sanding-monitoring-web-app': minor
+---
+
+Add Cancelled badge to StatusBadge

--- a/src/AppInterface.css
+++ b/src/AppInterface.css
@@ -526,7 +526,7 @@ button:focus {
 }
 
 .status-badge-width {
-  width: 70px;
+  width: 90px;
 }
 
 .error-text {

--- a/src/components/StatusBadge.tsx
+++ b/src/components/StatusBadge.tsx
@@ -13,7 +13,7 @@ const getStatus = (pass: Pass): { label: string; className: string } => {
       return { label: 'Cancelled', className: 'bg-orange-100 text-orange-800' }
     }
     // Any other state (e.g. Executing, GeneratingMesh) is in progress
-    return { label: pass.current_state, className: 'bg-blue-100 text-blue-800' }
+    return { label: 'In Progress', className: 'bg-blue-100 text-blue-800' }
   }
 
   // Legacy fallback for records without current_state
@@ -27,7 +27,7 @@ export const StatusBadge = (props: { pass: Pass }) => {
   const { label, className } = getStatus(props.pass)
   return (
     <span
-      className={`moveleft inline-flex items-center justify-center py-1 rounded-full text-xs font-medium status-badge-width ${className}`}
+      className={`moveleft inline-flex items-center justify-center px-3 py-1.5 rounded-full text-xs font-medium status-badge-width ${className}`}
     >
       {label}
     </span>

--- a/src/components/StatusBadge.tsx
+++ b/src/components/StatusBadge.tsx
@@ -9,6 +9,9 @@ const getStatus = (pass: Pass): { label: string; className: string } => {
     if (pass.current_state === 'Failed') {
       return { label: 'Failed', className: 'bg-red-100 text-red-800' }
     }
+    if (pass.current_state === 'Cancelled') {
+      return { label: 'Cancelled', className: 'bg-orange-100 text-orange-800' }
+    }
     // Any other state (e.g. Executing, GeneratingMesh) is in progress
     return { label: pass.current_state, className: 'bg-blue-100 text-blue-800' }
   }


### PR DESCRIPTION
# Overview
- Distinguish between cancelled and failed when possible
- Display `In Progress` instead of specific state machine states for now

# Manual Testing
<img width="2284" height="668" alt="Screenshot 2026-04-22 at 3 02 14 PM" src="https://github.com/user-attachments/assets/c6d2ae66-7c97-4459-998b-9bcaee62fed7" />
