### PR TITLE
Show dashes for unset end times; label abandoned in-progress passes as Incomplete

### DIFF
--- a/.changeset/pink-flowers-pull.md
+++ b/.changeset/pink-flowers-pull.md
@@ -1,0 +1,5 @@
+---
+'sanding-monitoring-web-app': minor
+---
+
+Show dashes for unset end times; label abandoned in-progress passes as Incomplete

--- a/src/SinglePassPage.tsx
+++ b/src/SinglePassPage.tsx
@@ -157,7 +157,7 @@ function SinglePassPage() {
         <div className="font-semibold text-zinc-900 text-sm">
           Pass {pass.pass_id.substring(0, 8)}
         </div>
-        <StatusBadge pass={pass} />
+        <StatusBadge pass={pass} isIncomplete={false} />
         <div className="text-sm text-zinc-600">
           {pass.start.toLocaleString()} – {pass.end.toLocaleTimeString()}
         </div>
@@ -166,7 +166,7 @@ function SinglePassPage() {
       <main className="mainContent">
         <CameraProvider>
           <VideoStoreProvider>
-            <SinglePassProvider pass={pass}>
+            <SinglePassProvider pass={pass} isIncomplete={false}>
               <ResourceSelection />
               <SinglePassPageContent />
             </SinglePassProvider>

--- a/src/components/HistoryTable/CollapsedRow.tsx
+++ b/src/components/HistoryTable/CollapsedRow.tsx
@@ -1,5 +1,5 @@
 import { formatDurationToMinutesSeconds } from '../../lib/videoUtils'
-import { getExecutionTimeMs } from '../../lib/passUtils'
+import { getExecutionTimeMs, isInProgress } from '../../lib/passUtils'
 import { StatusBadge } from '../StatusBadge'
 import { useMemo, useState } from 'react'
 import { usePass } from '../../lib/contexts/PassContext'
@@ -18,7 +18,7 @@ export const CollapsedRow = ({
   pieceColor,
 }: CollapsedRowProps) => {
   const { passNotes, passDiagnoses } = usePass()
-  const { pass } = useSinglePass()
+  const { pass, isIncomplete } = useSinglePass()
   const [errorsExpanded, setErrorsExpanded] = useState<boolean>(false)
   const passNotesData = passNotes.get(pass.pass_id) || []
   const execMs = useMemo(() => {
@@ -203,15 +203,17 @@ export const CollapsedRow = ({
         )}
       </td>
       <td>
-        <StatusBadge pass={pass} />
+        <StatusBadge pass={pass} isIncomplete={isIncomplete} />
       </td>
       <td className="text-zinc-700">{pass.start.toLocaleTimeString()}</td>
-      <td className="text-zinc-700">{pass.end.toLocaleTimeString()}</td>
       <td className="text-zinc-700">
-        {formatDurationToMinutesSeconds(pass.start, pass.end)}
+        {isInProgress(pass) ? '—' : pass.end.toLocaleTimeString()}
       </td>
       <td className="text-zinc-700">
-        {formatDurationToMinutesSeconds(new Date(0), new Date(execMs))}
+        {isInProgress(pass) ? '—' : formatDurationToMinutesSeconds(pass.start, pass.end)}
+      </td>
+      <td className="text-zinc-700">
+        {isInProgress(pass) ? '—' : formatDurationToMinutesSeconds(new Date(0), new Date(execMs))}
       </td>
       <td className="text-zinc-700">
         {pass.pass_mode ? (

--- a/src/components/HistoryTable/index.tsx
+++ b/src/components/HistoryTable/index.tsx
@@ -6,6 +6,7 @@ import { usePagination } from '../../lib/contexts/PaginationContext'
 import { lazy } from 'react'
 import { SinglePassProvider } from '../../lib/contexts/SinglePassContext.tsx'
 import { computePieceColors } from '../../lib/pieceColorUtils'
+import { isInProgress } from '../../lib/passUtils'
 const Row = lazy(() => import('./Row.tsx'))
 
 const HistoryTable: React.FC = () => {
@@ -24,9 +25,41 @@ const HistoryTable: React.FC = () => {
     }, {})
   }, [currentPassSummaries])
 
-  // Memoize day aggregates calculation - calculate both execution percentage AND total time
-  const dayAggregates = useMemo(() => {
-    return Object.entries(groupedPasses).reduce(
+  // Memoize day aggregates and incomplete pass IDs together.
+  // "Incomplete" is determined globally: an in-progress pass is incomplete whenever
+  // any later pass (of any status, on any day) exists. Only an in-progress pass with
+  // the globally latest start time is treated as actively running.
+  const { dayAggregates, incompletePassIds } = useMemo(() => {
+    // Sort all visible passes ascending by start time so we can:
+    // 1. Find the global latest start time
+    // 2. Look up each pass's immediate successor across day boundaries
+    const allSortedPasses = Object.values(groupedPasses)
+      .flat()
+      .sort((a, b) => a.start.getTime() - b.start.getTime())
+
+    const globalMaxStartTime =
+      allSortedPasses.length > 0
+        ? allSortedPasses[allSortedPasses.length - 1].start.getTime()
+        : 0
+
+    // Map each pass to its global successor's start time (used for incomplete end inference)
+    const nextPassStartByPassId = new Map<string, Date>()
+    for (let i = 0; i < allSortedPasses.length - 1; i++) {
+      nextPassStartByPassId.set(
+        allSortedPasses[i].pass_id,
+        allSortedPasses[i + 1].start
+      )
+    }
+
+    // An in-progress pass is incomplete if any pass (of any status) started after it
+    const incompletePassIds = new Set<string>()
+    for (const pass of allSortedPasses) {
+      if (isInProgress(pass) && pass.start.getTime() < globalMaxStartTime) {
+        incompletePassIds.add(pass.pass_id)
+      }
+    }
+
+    const dayAggregates = Object.entries(groupedPasses).reduce(
       (acc: Record<string, DayAggregateData>, [dateKey, passes]) => {
         let totalFactoryTime = 0
         let totalExecutionTime = 0
@@ -34,18 +67,26 @@ const HistoryTable: React.FC = () => {
         const symptomCounts = new Map<string, number>()
         const causeCounts = new Map<string, number>()
 
-        // Calculate both time and execution metrics
         passes.forEach((pass) => {
-          // Add pass duration to total time
-          const passDuration = pass.end.getTime() - pass.start.getTime()
-          totalFactoryTime += passDuration
+          // For in-progress passes the backend sends zeros for end time.
+          // Infer a meaningful end: use the globally next pass's start for incomplete
+          // passes (works across day boundaries), or current time for the active pass.
+          let inferredEnd: Date
+          if (!isInProgress(pass)) {
+            inferredEnd = pass.end
+          } else if (incompletePassIds.has(pass.pass_id)) {
+            inferredEnd = nextPassStartByPassId.get(pass.pass_id) ?? new Date()
+          } else {
+            inferredEnd = new Date()
+          }
 
-          // Calculate execution time for percentage
-          if (pass.steps && Array.isArray(pass.steps)) {
+          totalFactoryTime += inferredEnd.getTime() - pass.start.getTime()
+
+          // Only count step times for completed passes — in-progress step end
+          // times are also unreliable (zeros from the backend).
+          if (!isInProgress(pass) && pass.steps && Array.isArray(pass.steps)) {
             pass.steps.forEach((step) => {
               const stepDuration = step.end.getTime() - step.start.getTime()
-
-              // Look for the specific "executing" step (exact match or case-insensitive)
               if (step.name.toLowerCase() === 'executing') {
                 totalExecutionTime += stepDuration
               } else {
@@ -102,6 +143,8 @@ const HistoryTable: React.FC = () => {
       },
       {}
     )
+
+    return { dayAggregates, incompletePassIds }
   }, [groupedPasses, passDiagnoses])
 
   const pieceColors = useMemo(() => {
@@ -143,7 +186,7 @@ const HistoryTable: React.FC = () => {
                   const globalIndex = `${dayIndex}-${passIndex}`
                   return (
                     <React.Fragment key={globalIndex}>
-                      <SinglePassProvider pass={pass}>
+                      <SinglePassProvider pass={pass} isIncomplete={incompletePassIds.has(pass.pass_id)}>
                         <Suspense
                           fallback={
                             <tr>

--- a/src/components/StatusBadge.tsx
+++ b/src/components/StatusBadge.tsx
@@ -2,7 +2,7 @@ import { Pass } from '../lib/types'
 
 const getStatus = (
   pass: Pass,
-  isIncomplete = false
+  isIncomplete: boolean
 ): { label: string; className: string } => {
   // Use current_state as the primary signal (set by backend on all new records)
   if (pass.current_state) {
@@ -30,7 +30,7 @@ const getStatus = (
   return { label: 'Failed', className: 'bg-red-100 text-red-800' }
 }
 
-export const StatusBadge = (props: { pass: Pass; isIncomplete?: boolean }) => {
+export const StatusBadge = (props: { pass: Pass; isIncomplete: boolean }) => {
   const { label, className } = getStatus(props.pass, props.isIncomplete)
   return (
     <span

--- a/src/components/StatusBadge.tsx
+++ b/src/components/StatusBadge.tsx
@@ -1,6 +1,9 @@
 import { Pass } from '../lib/types'
 
-const getStatus = (pass: Pass): { label: string; className: string } => {
+const getStatus = (
+  pass: Pass,
+  isIncomplete = false
+): { label: string; className: string } => {
   // Use current_state as the primary signal (set by backend on all new records)
   if (pass.current_state) {
     if (pass.current_state === 'Succeeded') {
@@ -12,7 +15,11 @@ const getStatus = (pass: Pass): { label: string; className: string } => {
     if (pass.current_state === 'Cancelled') {
       return { label: 'Cancelled', className: 'bg-orange-100 text-orange-800' }
     }
-    // Any other state (e.g. Executing, GeneratingMesh) is in progress
+    // A non-most-recent in-progress pass was cut out before finishing
+    if (isIncomplete) {
+      return { label: 'Incomplete', className: 'bg-amber-100 text-amber-800' }
+    }
+    // Any other state (e.g. Executing, GeneratingMesh) is actively in progress
     return { label: 'In Progress', className: 'bg-blue-100 text-blue-800' }
   }
 
@@ -23,8 +30,8 @@ const getStatus = (pass: Pass): { label: string; className: string } => {
   return { label: 'Failed', className: 'bg-red-100 text-red-800' }
 }
 
-export const StatusBadge = (props: { pass: Pass }) => {
-  const { label, className } = getStatus(props.pass)
+export const StatusBadge = (props: { pass: Pass; isIncomplete?: boolean }) => {
+  const { label, className } = getStatus(props.pass, props.isIncomplete)
   return (
     <span
       className={`moveleft inline-flex items-center justify-center px-3 py-1.5 rounded-full text-xs font-medium status-badge-width ${className}`}

--- a/src/lib/contexts/SinglePassContext.tsx
+++ b/src/lib/contexts/SinglePassContext.tsx
@@ -18,6 +18,7 @@ import {
 
 interface SinglePassContextType {
   pass: Pass
+  isIncomplete: boolean  // true when this pass was cut out and a newer pass exists
 
   isFetchingImages: boolean
   areImagesLoaded: boolean
@@ -48,9 +49,11 @@ const SinglePassContext = createContext<SinglePassContextType | undefined>(
 
 export function SinglePassProvider({
   pass,
+  isIncomplete = false,
   children,
 }: {
   pass: Pass
+  isIncomplete?: boolean
   children: ReactNode
 }) {
   const { registerCameraNames } = useCamera()
@@ -213,6 +216,7 @@ export function SinglePassProvider({
     <SinglePassContext.Provider
       value={{
         pass,
+        isIncomplete,
         isFetchingImages,
         areImagesLoaded,
         images,

--- a/src/lib/contexts/SinglePassContext.tsx
+++ b/src/lib/contexts/SinglePassContext.tsx
@@ -49,11 +49,11 @@ const SinglePassContext = createContext<SinglePassContextType | undefined>(
 
 export function SinglePassProvider({
   pass,
-  isIncomplete = false,
+  isIncomplete,
   children,
 }: {
   pass: Pass
-  isIncomplete?: boolean
+  isIncomplete: boolean
   children: ReactNode
 }) {
   const { registerCameraNames } = useCamera()

--- a/src/lib/passUtils.ts
+++ b/src/lib/passUtils.ts
@@ -99,6 +99,12 @@ export const getStepVideos = (
   return { fullVideos, last30sVideos }
 }
 
+// Returns true if the pass has not yet completed (end time is unreliable)
+export const isInProgress = (pass: Pass): boolean => {
+  if (!pass.current_state) return false
+  return !['Succeeded', 'Failed', 'Cancelled'].includes(pass.current_state)
+}
+
 // Compute total execution time (ms) for a pass by summing 'executing' steps
 export const getExecutionTimeMs = (pass: Pass): number => {
   if (!pass.steps || pass.steps.length === 0) return 0


### PR DESCRIPTION
## Description
When a pass is cut out, the backend sends zeros for end, causing epoch-based timestamps to display and day aggregate totals to go deeply negative
- Show "—" for end time and duration on any in-progress pass
- Label abandoned in-progress passes (where a newer pass exists) as "Incomplete" with an amber badge
- Fix day aggregate by inferring end time: next pass's start for incomplete passes, Date.now() for the actively running one

## Testing
### Before
<img width="1428" height="482" alt="Screenshot 2026-04-29 at 11 32 58 AM" src="https://github.com/user-attachments/assets/6f3254e5-c602-475e-957c-9bb953ea9407" />

### With this change
<img width="1915" height="611" alt="Screenshot 2026-04-29 at 11 32 50 AM" src="https://github.com/user-attachments/assets/92d63b0f-8c06-4269-963f-644d2caf97d8" />
