### PR TITLE
Upgrade @viamrobotics/motion-tools to 1.22.0

### DIFF
--- a/.changeset/upgrade-motion-tools.md
+++ b/.changeset/upgrade-motion-tools.md
@@ -1,0 +1,8 @@
+---
+"sanding-monitoring-web-app": minor
+---
+
+Upgrade @viamrobotics/motion-tools from 1.2.2 to 1.22.0. This pulls the snapshot
+viewer onto the threlte/three.js rendering stack, so the build now requires
+vite-plugin-glsl, HDR asset handling, and pinned three@0.183.2 (matching the
+sibling sanding-webapp integration).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,22 +1,30 @@
 {
   "name": "sanding-monitoring-web-app",
-  "version": "1.13.1",
+  "version": "1.19.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sanding-monitoring-web-app",
-      "version": "1.13.1",
+      "version": "1.19.0",
       "dependencies": {
+        "@ag-grid-community/client-side-row-model": "^32.3.9",
+        "@ag-grid-community/core": "^32.3.9",
+        "@ag-grid-community/styles": "^32.3.9",
         "@tanstack/svelte-query": "^5.69.0",
-        "@viamrobotics/motion-tools": "1.2.2",
+        "@threlte/core": "^8.5.16",
+        "@threlte/extras": "^9.20.1",
+        "@viamrobotics/motion-tools": "1.22.0",
         "@viamrobotics/prime-core": "0.1.5",
         "@viamrobotics/sdk": "^0.57.0",
         "@viamrobotics/svelte-sdk": "^1.0.1",
         "js-cookie": "^3.0.5",
+        "koota": "^0.6.5",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^7.10.1",
+        "runed": "^0.37.1",
+        "three": "0.183.2",
         "vitest": "^4.1.0"
       },
       "devDependencies": {
@@ -45,7 +53,8 @@
         "typescript": "^5.0.0",
         "typescript-eslint": "^8.50.0",
         "vite": "^7.3.0",
-        "vite-bundle-analyzer": "^1.3.2"
+        "vite-bundle-analyzer": "^1.3.2",
+        "vite-plugin-glsl": "^1.6.0"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -60,7 +69,6 @@
       "resolved": "https://registry.npmjs.org/@ag-grid-community/client-side-row-model/-/client-side-row-model-32.3.9.tgz",
       "integrity": "sha512-/x6gPhxn6c/QQSmDuNf81xrBNc3TKGymmokznvXPPf4tAXeLZn5kF0cW3sGa52XyqZcIsYFQvLkI+pCsX+I4ng==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ag-grid-community/core": "32.3.9",
         "tslib": "^2.3.0"
@@ -71,7 +79,6 @@
       "resolved": "https://registry.npmjs.org/@ag-grid-community/core/-/core-32.3.9.tgz",
       "integrity": "sha512-oZeAEPgaJVMzfKqbAPCyadcN5+iy+tjvhRLqEYJdBxtLgW/s2s0qXcXQvnrz7eUMD3Z7h3BQRVt2h/p0T6Ox/w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ag-charts-types": "10.3.9",
         "tslib": "^2.3.0"
@@ -81,8 +88,7 @@
       "version": "32.3.9",
       "resolved": "https://registry.npmjs.org/@ag-grid-community/styles/-/styles-32.3.9.tgz",
       "integrity": "sha512-uPNR5EXeQqAIC0gohmY7CJ97cTIA/JtNSqAUzJ8AdVZcz4dbk9JJIl9DRFUYL+qWhMY+fUSTw2a+Yi6aOGSs8A==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.3.0",
@@ -182,7 +188,6 @@
       "version": "7.28.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -427,8 +432,7 @@
     },
     "node_modules/@bufbuild/protobuf": {
       "version": "1.10.1",
-      "license": "(Apache-2.0 AND BSD-3-Clause)",
-      "peer": true
+      "license": "(Apache-2.0 AND BSD-3-Clause)"
     },
     "node_modules/@changesets/apply-release-plan": {
       "version": "7.0.14",
@@ -796,7 +800,6 @@
     "node_modules/@connectrpc/connect": {
       "version": "1.6.1",
       "license": "Apache-2.0",
-      "peer": true,
       "peerDependencies": {
         "@bufbuild/protobuf": "^1.10.0"
       }
@@ -897,7 +900,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -946,7 +948,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -1529,28 +1530,28 @@
       }
     },
     "node_modules/@floating-ui/core": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.3.tgz",
-      "integrity": "sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w==",
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
+      "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
       "license": "MIT",
       "dependencies": {
-        "@floating-ui/utils": "^0.2.10"
+        "@floating-ui/utils": "^0.2.11"
       }
     },
     "node_modules/@floating-ui/dom": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.4.tgz",
-      "integrity": "sha512-OOchDgh4F2CchOX94cRVqhvy7b3AFb+/rQXyswmzmGakRfkMgoWVjfnLWkRirfLEfuD4ysVW16eXzwt3jHIzKA==",
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
+      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
       "license": "MIT",
       "dependencies": {
-        "@floating-ui/core": "^1.7.3",
-        "@floating-ui/utils": "^0.2.10"
+        "@floating-ui/core": "^1.7.5",
+        "@floating-ui/utils": "^0.2.11"
       }
     },
     "node_modules/@floating-ui/utils": {
-      "version": "0.2.10",
-      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
-      "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
+      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
       "license": "MIT"
     },
     "node_modules/@humanfs/core": {
@@ -2201,7 +2202,6 @@
       "integrity": "sha512-YZs/OSKOQAQCnJvM/P+F1URotNnYNeU3P2s4oIpzm1uFaqUEqRxUB0g5ejMjEb5Gjb9/PiBI5Ktrq4rUUF8UVQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@sveltejs/vite-plugin-svelte-inspector": "^5.0.0",
         "debug": "^4.4.1",
@@ -2814,6 +2814,7 @@
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -2903,25 +2904,20 @@
       }
     },
     "node_modules/@threlte/core": {
-      "version": "8.3.1",
-      "resolved": "https://registry.npmjs.org/@threlte/core/-/core-8.3.1.tgz",
-      "integrity": "sha512-qKjjNCQ+40hyeBcfOMh/8ef5x/j5PG5Wmo/L9Ye0aDCcdD6fCewWxfp7tV/J3CxPzX1dEp1JGK7sjyc7ntZSrg==",
+      "version": "8.5.16",
+      "resolved": "https://registry.npmjs.org/@threlte/core/-/core-8.5.16.tgz",
+      "integrity": "sha512-+aa9Zgz0/Qat82H0hTm1pTEtS2BIP1Nfu7pKaei+3+TvDqER0YnZ4hdgI9fYU9Z5r1lrzY3JxMyrdISp4B0kfw==",
       "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "mitt": "^3.0.1"
-      },
       "peerDependencies": {
         "svelte": ">=5",
         "three": ">=0.160"
       }
     },
     "node_modules/@threlte/extras": {
-      "version": "9.7.1",
-      "resolved": "https://registry.npmjs.org/@threlte/extras/-/extras-9.7.1.tgz",
-      "integrity": "sha512-SGm59HDCdHxADFHuweHfFDknwubkCPodyK0pbfsVtOWWOX26gE2xfK7aKolh6YFDiPAjWjGxN0jIgkNbbr1ohg==",
+      "version": "9.20.1",
+      "resolved": "https://registry.npmjs.org/@threlte/extras/-/extras-9.20.1.tgz",
+      "integrity": "sha512-eWfTKw0IjZIaWlqD4B3+63iBsOFGxgSt3pitvo4ar6KgEjIyMR68X/CP64sBTDxwrsDDy0+vKEVGnX9mM0KPtA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@threejs-kit/instanced-sprite-mesh": "^2.5.1",
         "camera-controls": "^3.1.2",
@@ -2958,18 +2954,27 @@
         "three": ">=0.160"
       }
     },
+    "node_modules/@tweakpane/core": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@tweakpane/core/-/core-2.0.5.tgz",
+      "integrity": "sha512-punBgD5rKCF5vcNo6BsSOXiDR/NSs9VM7SG65QSLJIxfRaGgj54ree9zQW6bO3pNFf3AogiGgaNODUVQRk9YqQ==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@tweenjs/tween.js": {
       "version": "23.1.3",
       "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-23.1.3.tgz",
       "integrity": "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/aria-query": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -3056,7 +3061,6 @@
       "integrity": "sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -3068,7 +3072,6 @@
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -3098,13 +3101,15 @@
       "version": "0.17.4",
       "resolved": "https://registry.npmjs.org/@types/stats.js/-/stats.js-0.17.4.tgz",
       "integrity": "sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/three": {
       "version": "0.182.0",
       "resolved": "https://registry.npmjs.org/@types/three/-/three-0.182.0.tgz",
       "integrity": "sha512-WByN9V3Sbwbe2OkWuSGyoqQO8Du6yhYaXtXLoA5FkKTUJorZ+yOHBZ35zUUPQXlAKABZmbYp5oAqpA4RBjtJ/Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@dimforge/rapier3d-compat": "~0.12.0",
         "@tweenjs/tween.js": "~23.1.3",
@@ -3119,13 +3124,15 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/@dimforge/rapier3d-compat/-/rapier3d-compat-0.12.0.tgz",
       "integrity": "sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/@types/webxr": {
       "version": "0.5.24",
       "resolved": "https://registry.npmjs.org/@types/webxr/-/webxr-0.5.24.tgz",
       "integrity": "sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.50.0",
@@ -3166,7 +3173,6 @@
       "version": "8.50.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.50.0",
         "@typescript-eslint/types": "8.50.0",
@@ -3370,16 +3376,21 @@
       }
     },
     "node_modules/@viamrobotics/motion-tools": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@viamrobotics/motion-tools/-/motion-tools-1.2.2.tgz",
-      "integrity": "sha512-TD2UjuAi814da3DtU4EEEV3gVAkmCcpzrJGUMjGtkQ/ioDdpVk6eYUeTsEpoyeps0yhTNuZ39Y9IaO27rK1TSA==",
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/@viamrobotics/motion-tools/-/motion-tools-1.22.0.tgz",
+      "integrity": "sha512-q06/nuYg2r36khEKvLNmQjK8J5OxfpnMhq/1/fvtb4z4DL9+w2t6fHelntGXJy6NT5LXsyoIETyywm6PF7AaJw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@bufbuild/protobuf": "1.10.1",
+        "@connectrpc/connect": "1.7.0",
+        "@connectrpc/connect-web": "1.7.0",
         "@neodrag/svelte": "^2.3.3",
         "@tanstack/svelte-query-devtools": "^6.0.2",
-        "koota": "^0.5.3",
-        "lodash-es": "4.17.21",
+        "earcut": "^3.0.2",
+        "filtrex": "^3.1.0",
+        "koota": "0.6.5",
+        "lodash-es": "4.18.1",
+        "three-mesh-bvh": "^0.9.8",
         "uuid-tool": "^2.0.3"
       },
       "engines": {
@@ -3400,14 +3411,37 @@
         "@zag-js/collapsible": ">=1",
         "@zag-js/dialog": ">=1.31",
         "@zag-js/floating-panel": ">=1",
+        "@zag-js/popover": ">=1",
         "@zag-js/svelte": ">=1",
+        "@zag-js/tabs": ">=1",
+        "@zag-js/toggle-group": ">=1",
         "@zag-js/tree-view": ">=1",
         "camera-controls": ">=3",
         "idb-keyval": ">=6",
         "lucide-svelte": ">=0.511",
         "runed": ">=0.28",
         "svelte": ">=5",
+        "svelte-tweakpane-ui": ">=1.5",
         "svelte-virtuallists": ">=1"
+      }
+    },
+    "node_modules/@viamrobotics/motion-tools/node_modules/@connectrpc/connect": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@connectrpc/connect/-/connect-1.7.0.tgz",
+      "integrity": "sha512-iNKdJRi69YP3mq6AePRT8F/HrxWCewrhxnLMNm0vpqXAR8biwzRtO6Hjx80C6UvtKJ5sFmffQT7I4Baecz389w==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.10.0"
+      }
+    },
+    "node_modules/@viamrobotics/motion-tools/node_modules/@connectrpc/connect-web": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@connectrpc/connect-web/-/connect-web-1.7.0.tgz",
+      "integrity": "sha512-qyP0YOnUPRWwCc/VfsoydMJvkb7EyUPr2q9sHgBuJzbADjiqck1gKH5V5ZPzPhTLBvmz5UvG+wiZ5sMRQHU1MQ==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.10.0",
+        "@connectrpc/connect": "1.7.0"
       }
     },
     "node_modules/@viamrobotics/motion-tools/node_modules/@tanstack/query-core": {
@@ -3415,6 +3449,7 @@
       "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.90.16.tgz",
       "integrity": "sha512-MvtWckSVufs/ja463/K4PyJeqT+HMlJWtw6PrCpywznd2NSgO3m4KwO9RqbFqGg6iDE8vVMFWMeQI4Io3eEYww==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
@@ -3455,18 +3490,17 @@
         "svelte": "^5.25.0"
       }
     },
-    "node_modules/@viamrobotics/motion-tools/node_modules/lodash-es": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
-      "license": "MIT"
+    "node_modules/@viamrobotics/motion-tools/node_modules/earcut": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/earcut/-/earcut-3.0.2.tgz",
+      "integrity": "sha512-X7hshQbLyMJ/3RPhyObLARM2sNxxmRALLKx1+NVFFnQ9gKzmCrxm9+uLIAdBcvc8FNLpctqlQ2V6AE92Ol9UDQ==",
+      "license": "ISC"
     },
     "node_modules/@viamrobotics/prime-core": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/@viamrobotics/prime-core/-/prime-core-0.1.5.tgz",
       "integrity": "sha512-vXOs+RP+/dfHDOvITrmGhrnDrgX5Cf6lGdNYW9QxC8ZtADCXat2/9VdxEXqx8v5ylEfd8Y9gE6oDJA9T/46ang==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@floating-ui/dom": "^1.5.3",
         "@mdi/js": "^7.3.67",
@@ -3503,7 +3537,6 @@
       "resolved": "https://registry.npmjs.org/@viamrobotics/sdk/-/sdk-0.57.0.tgz",
       "integrity": "sha512-9mZS3Gf0Er7OYZDruiUR3KrWUaK29DVvLt9wj13UxtriDs7hOHGLSlT29CrCQP9L8ZPiHTmr5O3C+CZG3c42jg==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@bufbuild/protobuf": "^1.10.0",
         "@connectrpc/connect": "^1.6.0",
@@ -3517,7 +3550,6 @@
       "resolved": "https://registry.npmjs.org/@viamrobotics/svelte-sdk/-/svelte-sdk-1.0.1.tgz",
       "integrity": "sha512-ywVzZpyOyr0BFZ1GoeUE+9cIZxfCdxpw+K/kZqzHDQM4AddHL5A4WrJezwO5SfQtn+jwrNX+ehj4pZDJB1zXXg==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@tanstack/svelte-query": "^6.0.8",
         "@tanstack/svelte-query-devtools": "^6.0.1",
@@ -3543,7 +3575,6 @@
       "resolved": "https://registry.npmjs.org/@tanstack/svelte-query/-/svelte-query-6.0.14.tgz",
       "integrity": "sha512-gKuHxbyGP2pCQgE/Px9FtlyFmHTt0OV5xTrKrk7PMKGkv3LPWTTwDb7xlMDe1V7U2K5ci+jq1j3HsuTPqIZxjA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@tanstack/query-core": "5.90.16"
       },
@@ -3571,6 +3602,22 @@
       "peerDependencies": {
         "@tanstack/svelte-query": "^6.0.12",
         "svelte": "^5.25.0"
+      }
+    },
+    "node_modules/@viamrobotics/svelte-sdk/node_modules/runed": {
+      "version": "0.29.2",
+      "resolved": "https://registry.npmjs.org/runed/-/runed-0.29.2.tgz",
+      "integrity": "sha512-0cq6cA6sYGZwl/FvVqjx9YN+1xEBu9sDDyuWdDW1yWX7JF2wmvmVKfH+hVCZs+csW+P3ARH92MjI3H9QTagOQA==",
+      "funding": [
+        "https://github.com/sponsors/huntabyte",
+        "https://github.com/sponsors/tglide"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "esm-env": "^1.0.0"
+      },
+      "peerDependencies": {
+        "svelte": "^5.7.0"
       }
     },
     "node_modules/@vitejs/plugin-react": {
@@ -3704,19 +3751,22 @@
       "version": "0.1.68",
       "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.68.tgz",
       "integrity": "sha512-3ab1B59Ojb6RwjOspYLsTpCzbNB3ZaamIAxBMmvnNkiDoLTZUOBXZ9p5nAYVEkQlDdf6qAZWi1pqj9+ypiqznA==",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/@zag-js/anatomy": {
       "version": "1.32.0",
       "resolved": "https://registry.npmjs.org/@zag-js/anatomy/-/anatomy-1.32.0.tgz",
       "integrity": "sha512-99u8VBSt5wkP9ZluIV6lR06Pvyt0AQaTGnvhZkvSmbz5U5+1XwCU0Db7Q+dcQRpM7d0p1ViWFxNVHDuuwY25Fw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@zag-js/aria-hidden": {
       "version": "1.32.0",
       "resolved": "https://registry.npmjs.org/@zag-js/aria-hidden/-/aria-hidden-1.32.0.tgz",
       "integrity": "sha512-rgOSWjFMbeFwGPCdUWaSFbb4GM0Ovdr6sM0ilHmGQeXsrYkfg56R/o7I4/8P0kDIi/hDoE5TwBMUiGvKwWMLgA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/dom-query": "1.32.0"
       }
@@ -3740,6 +3790,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/collection/-/collection-1.32.0.tgz",
       "integrity": "sha512-m4ViU0CdsTNiLjuIJknpPN8PPrsudfXC5GMAVykSBFnD6cnOWFKr7w4dM19Wp8VnlfsAsf4t86BPO+gsGm598w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/utils": "1.32.0"
       }
@@ -3749,6 +3800,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/core/-/core-1.32.0.tgz",
       "integrity": "sha512-aibBwyqw3saAzYBf2YHfuyOGt9kdNc4+ile3D1jbUsXiccLvGuFPP3+Ox7fULcILIiQhR0X6M+sTF17IyEMrYA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/dom-query": "1.32.0",
         "@zag-js/utils": "1.32.0"
@@ -3777,6 +3829,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/dismissable/-/dismissable-1.32.0.tgz",
       "integrity": "sha512-AUjajoaj2/3GfQvYJ5cdVwnov/dqAuS2N2dHRwxxSe/ktD4FbN/t0AcJ5Q2ojOuT6nBScEZQNd2vOrVgxLEiwQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/dom-query": "1.32.0",
         "@zag-js/interact-outside": "1.32.0",
@@ -3788,6 +3841,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/dom-query/-/dom-query-1.32.0.tgz",
       "integrity": "sha512-12XCCV1bchIFC7wjtYim5sEqUrAddzt0eysMTbBrCuK5r6TmLecwLtxUNKIRQ8adkCn0jqecUiuNyXojaArP3g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/types": "1.32.0"
       }
@@ -3814,6 +3868,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/focus-trap/-/focus-trap-1.32.0.tgz",
       "integrity": "sha512-irzYMaz1ycAnHOGLr4r6+3MwhfKnA67N9jPft9ejnE2QoTp40W+xp07K2KQNf6xN7Boe6xGlw8SwLBnGZw2eCQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/dom-query": "1.32.0"
       }
@@ -3823,16 +3878,147 @@
       "resolved": "https://registry.npmjs.org/@zag-js/interact-outside/-/interact-outside-1.32.0.tgz",
       "integrity": "sha512-OwQgBxijmv9ZXFu6WzhLRULJh0FoixuP6DJV9B2CGBKJZz4hbQAqVrW9PFaPiBuWOILZpZ/iI6ZDjkGSKZ0WHw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/dom-query": "1.32.0",
         "@zag-js/utils": "1.32.0"
       }
+    },
+    "node_modules/@zag-js/popover": {
+      "version": "1.41.1",
+      "resolved": "https://registry.npmjs.org/@zag-js/popover/-/popover-1.41.1.tgz",
+      "integrity": "sha512-qCr6Iqkom9gp+3dPYR//1D8LnhzoGn/y8q3s7ZEM2K707KfQ8hbihJgfqoXaxsGtlQj15iYgr7m2I0LWLpE78g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@zag-js/anatomy": "1.41.1",
+        "@zag-js/aria-hidden": "1.41.1",
+        "@zag-js/core": "1.41.1",
+        "@zag-js/dismissable": "1.41.1",
+        "@zag-js/dom-query": "1.41.1",
+        "@zag-js/focus-trap": "1.41.1",
+        "@zag-js/popper": "1.41.1",
+        "@zag-js/remove-scroll": "1.41.1",
+        "@zag-js/types": "1.41.1",
+        "@zag-js/utils": "1.41.1"
+      }
+    },
+    "node_modules/@zag-js/popover/node_modules/@zag-js/anatomy": {
+      "version": "1.41.1",
+      "resolved": "https://registry.npmjs.org/@zag-js/anatomy/-/anatomy-1.41.1.tgz",
+      "integrity": "sha512-wBQVpl8TC9O5AjeJrnmNdJWEUYorTi7iklOcySeXIeaz6D7Y0YY0YbEOSFNsRTpn/NQHwkPejf3i5qkKavNHXw==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@zag-js/popover/node_modules/@zag-js/aria-hidden": {
+      "version": "1.41.1",
+      "resolved": "https://registry.npmjs.org/@zag-js/aria-hidden/-/aria-hidden-1.41.1.tgz",
+      "integrity": "sha512-+iZ2gG/EygWQRfafcIL9MMgKIP9QCnW8SfxlO71FYEMrexvJyzxyPUxzBn2NfpH+gOogzLrr3lvPTYZu+0kCVQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@zag-js/dom-query": "1.41.1"
+      }
+    },
+    "node_modules/@zag-js/popover/node_modules/@zag-js/core": {
+      "version": "1.41.1",
+      "resolved": "https://registry.npmjs.org/@zag-js/core/-/core-1.41.1.tgz",
+      "integrity": "sha512-np7Tlf1EUK2ITojiX3aQy79LWIZhu4xxrS6pE8V/wD0h9JeQmhyNtyC147jqIE/AYjSunhMShsWp/+W1b5skjQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@zag-js/dom-query": "1.41.1",
+        "@zag-js/utils": "1.41.1"
+      }
+    },
+    "node_modules/@zag-js/popover/node_modules/@zag-js/dismissable": {
+      "version": "1.41.1",
+      "resolved": "https://registry.npmjs.org/@zag-js/dismissable/-/dismissable-1.41.1.tgz",
+      "integrity": "sha512-nM3j3lz8XaYfW755N+Itp08BVFYhKhjlQ3EiBlc3LYwse4h2K5O3FwK87Ckqd/rBKrAb4eYFCkGNFSvjk0U/8g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@zag-js/dom-query": "1.41.1",
+        "@zag-js/interact-outside": "1.41.1",
+        "@zag-js/utils": "1.41.1"
+      }
+    },
+    "node_modules/@zag-js/popover/node_modules/@zag-js/dom-query": {
+      "version": "1.41.1",
+      "resolved": "https://registry.npmjs.org/@zag-js/dom-query/-/dom-query-1.41.1.tgz",
+      "integrity": "sha512-f6hBV6fPc9Ok/Re/tsxqJ8NcgQzsASQ6YoulUKSQnZMGb7tr0Ks1IH3Hjy3+ARXvCaSjgDhPPXt5+bkieur4eg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@zag-js/types": "1.41.1"
+      }
+    },
+    "node_modules/@zag-js/popover/node_modules/@zag-js/focus-trap": {
+      "version": "1.41.1",
+      "resolved": "https://registry.npmjs.org/@zag-js/focus-trap/-/focus-trap-1.41.1.tgz",
+      "integrity": "sha512-+KZpzvo4PQJI2M4GYRVgSEyD+X6Pu+paBS1zGlex0FLK+gzUVU0UnEtA1cSNS2oVMyHuu58mBZyYSCmeuMt5XA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@zag-js/dom-query": "1.41.1"
+      }
+    },
+    "node_modules/@zag-js/popover/node_modules/@zag-js/interact-outside": {
+      "version": "1.41.1",
+      "resolved": "https://registry.npmjs.org/@zag-js/interact-outside/-/interact-outside-1.41.1.tgz",
+      "integrity": "sha512-N31jT0bBzCLBtAn31wVFxuxiOnXemNT+lKjK9j5HBZgrqgA/L3RdeV59aZ4Ar02Bb6F6DxU+MImzVvfgra1e6A==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@zag-js/dom-query": "1.41.1",
+        "@zag-js/utils": "1.41.1"
+      }
+    },
+    "node_modules/@zag-js/popover/node_modules/@zag-js/popper": {
+      "version": "1.41.1",
+      "resolved": "https://registry.npmjs.org/@zag-js/popper/-/popper-1.41.1.tgz",
+      "integrity": "sha512-y4WURt3LvOYYch1qVLC+iVP1fzFnkvLv57k6zXb33fYTtCuQvDFQQcAsbqXUe5J3dSNXKZzjXyzRqOid4rDacA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@floating-ui/dom": "^1.7.6",
+        "@zag-js/dom-query": "1.41.1",
+        "@zag-js/utils": "1.41.1"
+      }
+    },
+    "node_modules/@zag-js/popover/node_modules/@zag-js/remove-scroll": {
+      "version": "1.41.1",
+      "resolved": "https://registry.npmjs.org/@zag-js/remove-scroll/-/remove-scroll-1.41.1.tgz",
+      "integrity": "sha512-OihOx/EDghH4haEnwTsESMa9hUAOyau7hSgJBwu1cio/zozGJ5/umKRGGMe1v6Eh1len3B+iVEpMf65Rp2bSGg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@zag-js/dom-query": "1.41.1"
+      }
+    },
+    "node_modules/@zag-js/popover/node_modules/@zag-js/types": {
+      "version": "1.41.1",
+      "resolved": "https://registry.npmjs.org/@zag-js/types/-/types-1.41.1.tgz",
+      "integrity": "sha512-xhKEX61yvNa/6yofkNe7IihKyt3JLe4/k5JxaH0hj46V4S2Kac2cNAXPgnWHbl1gXGBcfLr+qLFzo4oLl+VdwA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "csstype": "3.2.3"
+      }
+    },
+    "node_modules/@zag-js/popover/node_modules/@zag-js/utils": {
+      "version": "1.41.1",
+      "resolved": "https://registry.npmjs.org/@zag-js/utils/-/utils-1.41.1.tgz",
+      "integrity": "sha512-IZGqDpQYvgCQlGcLTVCzWG5DEz318ZLVJhp8TtT9HPDNd+RJTcVHRja7z+vqQ0Su+wKZkuLlIh5gtraxQ+YX9Q==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@zag-js/popper": {
       "version": "1.32.0",
       "resolved": "https://registry.npmjs.org/@zag-js/popper/-/popper-1.32.0.tgz",
       "integrity": "sha512-nTSdbgZKIEERNEpNhMlbATRiKhMrxo0t2206MbVhrM52TuraIc+nRmJNwWKoagalXs62/TlSpFvXmcpVyfWTMQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@floating-ui/dom": "^1.7.4",
         "@zag-js/dom-query": "1.32.0",
@@ -3843,13 +4029,15 @@
       "version": "1.32.0",
       "resolved": "https://registry.npmjs.org/@zag-js/rect-utils/-/rect-utils-1.32.0.tgz",
       "integrity": "sha512-waBJL57PA90mYRMCDF7WNa3ZEfNhnWPu6lGqNB1Lh/1GMUzIto1X/Lw1oJoGig8Ui9Af9pgRG4QPyKSRULFgKQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@zag-js/remove-scroll": {
       "version": "1.32.0",
       "resolved": "https://registry.npmjs.org/@zag-js/remove-scroll/-/remove-scroll-1.32.0.tgz",
       "integrity": "sha512-gWx8z/8ayNo624ibET4cNWbdVLc8A0Vyy9L9t67KT/slrBjcOA/zp9JL3Ngw/TZKgtR+wDh7P8ZoNAe0euaLSQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/dom-query": "1.32.0"
       }
@@ -3859,6 +4047,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/store/-/store-1.32.0.tgz",
       "integrity": "sha512-m9jvTKJB/lTC2I8NpDf+yo2XVN+ogxjiVbGsooAFTpyUAiXZY50nVc9cFcswnwFMo/GzXMk81oalyz9u65jqRQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "proxy-compare": "3.0.1"
       }
@@ -3877,6 +4066,124 @@
       "peerDependencies": {
         "svelte": ">=5"
       }
+    },
+    "node_modules/@zag-js/tabs": {
+      "version": "1.41.1",
+      "resolved": "https://registry.npmjs.org/@zag-js/tabs/-/tabs-1.41.1.tgz",
+      "integrity": "sha512-2rVX6TuT3bpdhfVYGY97ftRs5sDrp7oum4XlCYoFxQ/LpRTbiAfswsL1x97vrezCUBw0l5gmD6ePEn39BlGP+Q==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@zag-js/anatomy": "1.41.1",
+        "@zag-js/core": "1.41.1",
+        "@zag-js/dom-query": "1.41.1",
+        "@zag-js/types": "1.41.1",
+        "@zag-js/utils": "1.41.1"
+      }
+    },
+    "node_modules/@zag-js/tabs/node_modules/@zag-js/anatomy": {
+      "version": "1.41.1",
+      "resolved": "https://registry.npmjs.org/@zag-js/anatomy/-/anatomy-1.41.1.tgz",
+      "integrity": "sha512-wBQVpl8TC9O5AjeJrnmNdJWEUYorTi7iklOcySeXIeaz6D7Y0YY0YbEOSFNsRTpn/NQHwkPejf3i5qkKavNHXw==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@zag-js/tabs/node_modules/@zag-js/core": {
+      "version": "1.41.1",
+      "resolved": "https://registry.npmjs.org/@zag-js/core/-/core-1.41.1.tgz",
+      "integrity": "sha512-np7Tlf1EUK2ITojiX3aQy79LWIZhu4xxrS6pE8V/wD0h9JeQmhyNtyC147jqIE/AYjSunhMShsWp/+W1b5skjQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@zag-js/dom-query": "1.41.1",
+        "@zag-js/utils": "1.41.1"
+      }
+    },
+    "node_modules/@zag-js/tabs/node_modules/@zag-js/dom-query": {
+      "version": "1.41.1",
+      "resolved": "https://registry.npmjs.org/@zag-js/dom-query/-/dom-query-1.41.1.tgz",
+      "integrity": "sha512-f6hBV6fPc9Ok/Re/tsxqJ8NcgQzsASQ6YoulUKSQnZMGb7tr0Ks1IH3Hjy3+ARXvCaSjgDhPPXt5+bkieur4eg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@zag-js/types": "1.41.1"
+      }
+    },
+    "node_modules/@zag-js/tabs/node_modules/@zag-js/types": {
+      "version": "1.41.1",
+      "resolved": "https://registry.npmjs.org/@zag-js/types/-/types-1.41.1.tgz",
+      "integrity": "sha512-xhKEX61yvNa/6yofkNe7IihKyt3JLe4/k5JxaH0hj46V4S2Kac2cNAXPgnWHbl1gXGBcfLr+qLFzo4oLl+VdwA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "csstype": "3.2.3"
+      }
+    },
+    "node_modules/@zag-js/tabs/node_modules/@zag-js/utils": {
+      "version": "1.41.1",
+      "resolved": "https://registry.npmjs.org/@zag-js/utils/-/utils-1.41.1.tgz",
+      "integrity": "sha512-IZGqDpQYvgCQlGcLTVCzWG5DEz318ZLVJhp8TtT9HPDNd+RJTcVHRja7z+vqQ0Su+wKZkuLlIh5gtraxQ+YX9Q==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@zag-js/toggle-group": {
+      "version": "1.41.1",
+      "resolved": "https://registry.npmjs.org/@zag-js/toggle-group/-/toggle-group-1.41.1.tgz",
+      "integrity": "sha512-87LfeCB2nk5ZqOTPPjFLLNxneWUSnsC3W10i1satRqLKLdE+BLBJfPkhM+RK43jdrrneWIuRbaCFsARvJByY2g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@zag-js/anatomy": "1.41.1",
+        "@zag-js/core": "1.41.1",
+        "@zag-js/dom-query": "1.41.1",
+        "@zag-js/types": "1.41.1",
+        "@zag-js/utils": "1.41.1"
+      }
+    },
+    "node_modules/@zag-js/toggle-group/node_modules/@zag-js/anatomy": {
+      "version": "1.41.1",
+      "resolved": "https://registry.npmjs.org/@zag-js/anatomy/-/anatomy-1.41.1.tgz",
+      "integrity": "sha512-wBQVpl8TC9O5AjeJrnmNdJWEUYorTi7iklOcySeXIeaz6D7Y0YY0YbEOSFNsRTpn/NQHwkPejf3i5qkKavNHXw==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@zag-js/toggle-group/node_modules/@zag-js/core": {
+      "version": "1.41.1",
+      "resolved": "https://registry.npmjs.org/@zag-js/core/-/core-1.41.1.tgz",
+      "integrity": "sha512-np7Tlf1EUK2ITojiX3aQy79LWIZhu4xxrS6pE8V/wD0h9JeQmhyNtyC147jqIE/AYjSunhMShsWp/+W1b5skjQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@zag-js/dom-query": "1.41.1",
+        "@zag-js/utils": "1.41.1"
+      }
+    },
+    "node_modules/@zag-js/toggle-group/node_modules/@zag-js/dom-query": {
+      "version": "1.41.1",
+      "resolved": "https://registry.npmjs.org/@zag-js/dom-query/-/dom-query-1.41.1.tgz",
+      "integrity": "sha512-f6hBV6fPc9Ok/Re/tsxqJ8NcgQzsASQ6YoulUKSQnZMGb7tr0Ks1IH3Hjy3+ARXvCaSjgDhPPXt5+bkieur4eg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@zag-js/types": "1.41.1"
+      }
+    },
+    "node_modules/@zag-js/toggle-group/node_modules/@zag-js/types": {
+      "version": "1.41.1",
+      "resolved": "https://registry.npmjs.org/@zag-js/types/-/types-1.41.1.tgz",
+      "integrity": "sha512-xhKEX61yvNa/6yofkNe7IihKyt3JLe4/k5JxaH0hj46V4S2Kac2cNAXPgnWHbl1gXGBcfLr+qLFzo4oLl+VdwA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "csstype": "3.2.3"
+      }
+    },
+    "node_modules/@zag-js/toggle-group/node_modules/@zag-js/utils": {
+      "version": "1.41.1",
+      "resolved": "https://registry.npmjs.org/@zag-js/utils/-/utils-1.41.1.tgz",
+      "integrity": "sha512-IZGqDpQYvgCQlGcLTVCzWG5DEz318ZLVJhp8TtT9HPDNd+RJTcVHRja7z+vqQ0Su+wKZkuLlIh5gtraxQ+YX9Q==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@zag-js/tree-view": {
       "version": "1.32.0",
@@ -3898,6 +4205,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/types/-/types-1.32.0.tgz",
       "integrity": "sha512-9UV5mFnTgJRyFCCH9g/TIqtxxfw6FUphpe7E0AHK9+WSq3PRvflMeaRT/O6HgdWo0Rc+JN9vVwkFYyGD81uAbw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "3.2.3"
       }
@@ -3906,12 +4214,12 @@
       "version": "1.32.0",
       "resolved": "https://registry.npmjs.org/@zag-js/utils/-/utils-1.32.0.tgz",
       "integrity": "sha512-IRe1yFbMXBp8Q1Xp916Lq9P91s65K5KRNFZIv2EdQHRynLaT+QrPp5hmzkWoXJn8oOYd6PZeNb7K6v7vk8+k1g==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/acorn": {
       "version": "8.15.0",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4237,7 +4545,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001733",
         "electron-to-chromium": "^1.5.199",
@@ -4312,7 +4619,6 @@
       "resolved": "https://registry.npmjs.org/camera-controls/-/camera-controls-3.1.2.tgz",
       "integrity": "sha512-xkxfpG2ECZ6Ww5/9+kf4mfg1VEYAoe9aDSY+IwF0UEs7qEzwy0aVRfs2grImIECs/PoBtWFrh7RXsQkwG922JA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=22.0.0",
         "npm": ">=10.5.1"
@@ -4624,7 +4930,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -4691,7 +4996,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -4991,7 +5297,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5237,10 +5542,27 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-copy": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-4.0.3.tgz",
+      "integrity": "sha512-58apWr0GUiDFM8+3afrO6eYwJBn9ZAhDOzG3L+/9llab/haCARS2UIfffmOurYLwbgDRs8n0rfr6qAAPEAuAQw==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-equals": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-6.0.0.tgz",
+      "integrity": "sha512-PFhhIGgdM79r5Uztdj9Zb6Tt1zKafqVfdMGwVca1z5z6fbX7DmsySSuJd8HiP6I1j505DCS83cLxo5rmSNeVEA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/fast-glob": {
       "version": "3.3.3",
@@ -5311,7 +5633,8 @@
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
       "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
@@ -5336,6 +5659,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/filtrex": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/filtrex/-/filtrex-3.1.0.tgz",
+      "integrity": "sha512-mHzZ2wUISETF1OaEcNRiGz1ljuIV8c/C9td9qyAZ+wTwigkAk5RO9YrCxQKk5H9v7joDRFIBik9U5RTK9eXZ/A==",
+      "license": "MIT"
     },
     "node_modules/find-up": {
       "version": "5.0.0",
@@ -6235,7 +6564,6 @@
       "integrity": "sha512-9FshNB6OepopZ08unmmGpsF7/qCjxGPbo3NbgfJAnPeHXnsODE9WWffXZtRFRFe0ntzaAOcSKNJFz8wiyvF1jQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@asamuzakjp/css-color": "^5.0.1",
         "@asamuzakjp/dom-selector": "^7.0.2",
@@ -6351,9 +6679,9 @@
       }
     },
     "node_modules/koota": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/koota/-/koota-0.5.3.tgz",
-      "integrity": "sha512-mGTOSeVgHqAe/AtsChSv3IaFwzEWFvrDSGVv0tXqMX9ttaDMg+1DlnLaD/PpMZ6xQx4U1H2AdUjvsjFoJnFMsA==",
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/koota/-/koota-0.6.5.tgz",
+      "integrity": "sha512-FW4UVvYq0KP9/vv4K4Q0beHlDy6LLD2BMLgEqfM+0hcKhfJ5/TNqf1TbwdQxxL1+oNmALd168VltDdO7g/7cgA==",
       "license": "ISC",
       "peerDependencies": {
         "@types/react": ">=18.0.0",
@@ -6401,9 +6729,9 @@
       }
     },
     "node_modules/lodash-es": {
-      "version": "4.17.22",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.22.tgz",
-      "integrity": "sha512-XEawp1t0gxSi9x01glktRZ5HDy0HXqrM0x5pXQM98EaI0NxO6jVM7omDOxsuEo5UIASAnm2bRp1Jt/e0a2XU8Q==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
       "license": "MIT"
     },
     "node_modules/lodash.merge": {
@@ -6450,7 +6778,6 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "lz-string": "bin/bin.js"
@@ -6504,7 +6831,8 @@
       "version": "0.22.0",
       "resolved": "https://registry.npmjs.org/meshoptimizer/-/meshoptimizer-0.22.0.tgz",
       "integrity": "sha512-IebiK79sqIy+E4EgOr+CAw+Ke8hAspXKzBd0JdgEmPHiAwmvEj2S4h1rfvo+o/BnfEYd/jAOg5IeeIjzlzSnDg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
@@ -6576,12 +6904,6 @@
       "engines": {
         "node": ">= 18"
       }
-    },
-    "node_modules/mitt": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
-      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
-      "license": "MIT"
     },
     "node_modules/mri": {
       "version": "1.2.0",
@@ -6987,6 +7309,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -7002,6 +7325,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -7014,7 +7338,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/prism-themes": {
       "version": "1.9.0",
@@ -7045,7 +7370,8 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/proxy-compare/-/proxy-compare-3.0.1.tgz",
       "integrity": "sha512-V9plBAt3qjMlS1+nC8771KNf6oJ12gExvaxnNzN/9yVRLdTv/lc+oJlnSzrdYDAvBfTStPCoiaCOTmTs0adv7Q==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -7098,7 +7424,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -7111,7 +7436,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -7378,20 +7702,31 @@
       }
     },
     "node_modules/runed": {
-      "version": "0.29.2",
-      "resolved": "https://registry.npmjs.org/runed/-/runed-0.29.2.tgz",
-      "integrity": "sha512-0cq6cA6sYGZwl/FvVqjx9YN+1xEBu9sDDyuWdDW1yWX7JF2wmvmVKfH+hVCZs+csW+P3ARH92MjI3H9QTagOQA==",
+      "version": "0.37.1",
+      "resolved": "https://registry.npmjs.org/runed/-/runed-0.37.1.tgz",
+      "integrity": "sha512-MeFY73xBW8IueWBm012nNFIGy19WUGPLtknavyUPMpnyt350M47PhGSGrGoSLbidwn+Zlt/O0cp8/OZE3LASWA==",
       "funding": [
         "https://github.com/sponsors/huntabyte",
         "https://github.com/sponsors/tglide"
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "esm-env": "^1.0.0"
+        "dequal": "^2.0.3",
+        "esm-env": "^1.0.0",
+        "lz-string": "^1.5.0"
       },
       "peerDependencies": {
-        "svelte": "^5.7.0"
+        "@sveltejs/kit": "^2.21.0",
+        "svelte": "^5.7.0",
+        "zod": "^4.1.0"
+      },
+      "peerDependenciesMeta": {
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/safe-array-concat": {
@@ -7852,7 +8187,6 @@
       "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.46.1.tgz",
       "integrity": "sha512-ynjfCHD3nP2el70kN5Pmg37sSi0EjOm9FgHYQdC4giWG/hzO3AatzXXJJgP305uIhGQxSufJLuYWtkY8uK/8RA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jridgewell/remapping": "^2.3.4",
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -7872,6 +8206,220 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/svelte-persisted-store": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/svelte-persisted-store/-/svelte-persisted-store-0.12.0.tgz",
+      "integrity": "sha512-BdBQr2SGSJ+rDWH8/aEV5GthBJDapVP0GP3fuUCA7TjYG5ctcB+O9Mj9ZC0+Jo1oJMfZUd1y9H68NFRR5MyIJA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.14"
+      },
+      "peerDependencies": {
+        "svelte": "^3.48.0 || ^4 || ^5"
+      }
+    },
+    "node_modules/svelte-tweakpane-ui": {
+      "version": "1.5.17",
+      "resolved": "https://registry.npmjs.org/svelte-tweakpane-ui/-/svelte-tweakpane-ui-1.5.17.tgz",
+      "integrity": "sha512-gaA4epikaarGFAzEdkm9szpg0XvYW0GArCiYBUCZpXvbvws23b1gJJfULIGtj/gQ9WUxiQ/7PdcCaNqRf5r3Ag==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@kitschpatrol/tweakpane-plugin-camerakit": "0.3.1-beta.3",
+        "@kitschpatrol/tweakpane-plugin-essentials": "0.2.2-beta.3",
+        "@kitschpatrol/tweakpane-plugin-file-import": "1.1.2-beta.2",
+        "@kitschpatrol/tweakpane-plugin-image": "2.0.1-beta.8",
+        "@kitschpatrol/tweakpane-plugin-inputs": "1.0.4-beta.5",
+        "@kitschpatrol/tweakpane-plugin-profiler": "0.4.2-beta.3",
+        "@kitschpatrol/tweakpane-plugin-rotation": "0.2.1-beta.2",
+        "@kitschpatrol/tweakpane-plugin-textarea": "2.0.1-beta.2",
+        "@kitschpatrol/tweakpane-plugin-waveform": "1.0.4-beta.3",
+        "@tweakpane/core": "2.0.5",
+        "esm-env": "^1.2.2",
+        "fast-copy": "^4.0.3",
+        "fast-equals": "^6.0.0",
+        "nanoid": "^5.1.11",
+        "svelte-persisted-store": "0.12.0",
+        "tweakpane": "4.0.5"
+      },
+      "peerDependencies": {
+        "svelte": "^4.0.0 || ^5.0.0"
+      }
+    },
+    "node_modules/svelte-tweakpane-ui/node_modules/@kitschpatrol/tweakpane-plugin-camerakit": {
+      "version": "0.3.1-beta.3",
+      "resolved": "https://registry.npmjs.org/@kitschpatrol/tweakpane-plugin-camerakit/-/tweakpane-plugin-camerakit-0.3.1-beta.3.tgz",
+      "integrity": "sha512-Tg9TyaaeG7bfo4d6Bx1qtRBKWzs+8uYpN4FaxtyIcOJES6YjOXNAe7f23G2auSDuhkA8H62nqo4lnqxYOoyGEQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@tweakpane/core": "^2.0.5"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "tweakpane": "^4.0.0"
+      }
+    },
+    "node_modules/svelte-tweakpane-ui/node_modules/@kitschpatrol/tweakpane-plugin-essentials": {
+      "version": "0.2.2-beta.3",
+      "resolved": "https://registry.npmjs.org/@kitschpatrol/tweakpane-plugin-essentials/-/tweakpane-plugin-essentials-0.2.2-beta.3.tgz",
+      "integrity": "sha512-ucqdSQ16G8vCtifuQSr2sCtKCNWzhScOp4g+6p+uXRHIpOC73zHRAlLUndB2ZgjhOyA+0+2zQqBx22QnJkybaw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@tweakpane/core": "^2.0.5"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "tweakpane": "^4.0.0"
+      }
+    },
+    "node_modules/svelte-tweakpane-ui/node_modules/@kitschpatrol/tweakpane-plugin-file-import": {
+      "version": "1.1.2-beta.2",
+      "resolved": "https://registry.npmjs.org/@kitschpatrol/tweakpane-plugin-file-import/-/tweakpane-plugin-file-import-1.1.2-beta.2.tgz",
+      "integrity": "sha512-+W5DIOu2B/J0pmwSmxnF93TemJCvpMfvrcx5Opt8DYwsbtmFm0hRaHBO1dHmTeMJaBckOxWxIq22nJ4jcuwB4w==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@tweakpane/core": "^2.0.5"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "tweakpane": "^4.0.0"
+      }
+    },
+    "node_modules/svelte-tweakpane-ui/node_modules/@kitschpatrol/tweakpane-plugin-image": {
+      "version": "2.0.1-beta.8",
+      "resolved": "https://registry.npmjs.org/@kitschpatrol/tweakpane-plugin-image/-/tweakpane-plugin-image-2.0.1-beta.8.tgz",
+      "integrity": "sha512-QiJtvKPwrPWQ9rBR8DLWV0dY6AUiLuE8QcuuseK5EKXaTfc4KNMGI7ihaWw4FVayIzsEQyb7D6vwjeiW3dIqvA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@tweakpane/core": "^2.0.5"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "tweakpane": "^4.0.0"
+      }
+    },
+    "node_modules/svelte-tweakpane-ui/node_modules/@kitschpatrol/tweakpane-plugin-inputs": {
+      "version": "1.0.4-beta.5",
+      "resolved": "https://registry.npmjs.org/@kitschpatrol/tweakpane-plugin-inputs/-/tweakpane-plugin-inputs-1.0.4-beta.5.tgz",
+      "integrity": "sha512-R6YRWWCGtyBn14KXofgUJH7bV3mD5Vjhw8QyFTMQD6q8R9R7jD7uCsIxbU9hcduQID2diBvxT8bnLtWkyhrhVw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@tweakpane/core": "^2.0.5"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "tweakpane": "^4.0.0"
+      }
+    },
+    "node_modules/svelte-tweakpane-ui/node_modules/@kitschpatrol/tweakpane-plugin-profiler": {
+      "version": "0.4.2-beta.3",
+      "resolved": "https://registry.npmjs.org/@kitschpatrol/tweakpane-plugin-profiler/-/tweakpane-plugin-profiler-0.4.2-beta.3.tgz",
+      "integrity": "sha512-9vri0Oew3eO0K/F/jT58VAO3ersaQEfNfEqn5C0Np0zOOuFE+f1d/XgUKfiRPln9p3hrfNjbJ0kGBIfhBw+vzQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@tweakpane/core": "^2.0.5"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "tweakpane": "^4.0.0"
+      }
+    },
+    "node_modules/svelte-tweakpane-ui/node_modules/@kitschpatrol/tweakpane-plugin-rotation": {
+      "version": "0.2.1-beta.2",
+      "resolved": "https://registry.npmjs.org/@kitschpatrol/tweakpane-plugin-rotation/-/tweakpane-plugin-rotation-0.2.1-beta.2.tgz",
+      "integrity": "sha512-chGPIPjdiP18C71xDbO88IkpgaxwBSaFa6W5+XbmxTT5LpHXSyOTtOEv4cjPg85HDUG2Fc+h7tpnTw/3caCFRw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@tweakpane/core": "^2.0.5"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "tweakpane": "^4.0.0"
+      }
+    },
+    "node_modules/svelte-tweakpane-ui/node_modules/@kitschpatrol/tweakpane-plugin-textarea": {
+      "version": "2.0.1-beta.2",
+      "resolved": "https://registry.npmjs.org/@kitschpatrol/tweakpane-plugin-textarea/-/tweakpane-plugin-textarea-2.0.1-beta.2.tgz",
+      "integrity": "sha512-VHV6dJRlceyELapEd38Cwqtu+aG7VPX4e1anPxxVESQmb1uzr4LvsDWPYY6s+9XLzT7O1CZHg63Rd7rRn3bsDQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@tweakpane/core": "^2.0.5"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "tweakpane": "^4.0.0"
+      }
+    },
+    "node_modules/svelte-tweakpane-ui/node_modules/@kitschpatrol/tweakpane-plugin-waveform": {
+      "version": "1.0.4-beta.3",
+      "resolved": "https://registry.npmjs.org/@kitschpatrol/tweakpane-plugin-waveform/-/tweakpane-plugin-waveform-1.0.4-beta.3.tgz",
+      "integrity": "sha512-UVzLSoLQNnyvG3xwno+Mxl/O2rED0b7yz3UIl8gbU3eggJOsHMltywHpSuF7oIJYbbtQtjns6um/fhYyvzXnRQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@tweakpane/core": "^2.0.5"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "tweakpane": "^4.0.0"
+      }
+    },
+    "node_modules/svelte-tweakpane-ui/node_modules/nanoid": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.11.tgz",
+      "integrity": "sha512-v+KEsUv2ps74PaSKv0gHTxTCgMXOIfBEbaqa6w6ISIGC7ZsvHN4N9oJ8d4cmf0n5oTzQz2SLmThbQWhjd/8eKg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "nanoid": "bin/nanoid.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
+      }
+    },
+    "node_modules/svelte-tweakpane-ui/node_modules/tweakpane": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/tweakpane/-/tweakpane-4.0.5.tgz",
+      "integrity": "sha512-rxEXdSI+ArlG1RyO6FghC4ZUX8JkEfz8F3v1JuteXSV0pEtHJzyo07fcDG+NsJfN5L39kSbCYbB9cBGHyuI/tQ==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/cocopon"
       }
     },
     "node_modules/svelte-virtuallists": {
@@ -7967,11 +8515,10 @@
       }
     },
     "node_modules/three": {
-      "version": "0.182.0",
-      "resolved": "https://registry.npmjs.org/three/-/three-0.182.0.tgz",
-      "integrity": "sha512-GbHabT+Irv+ihI1/f5kIIsZ+Ef9Sl5A1Y7imvS5RQjWgtTPfPnZ43JmlYI7NtCRDK9zir20lQpfg8/9Yd02OvQ==",
-      "license": "MIT",
-      "peer": true
+      "version": "0.183.2",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.183.2.tgz",
+      "integrity": "sha512-di3BsL2FEQ1PA7Hcvn4fyJOlxRRgFYBpMTcyOgkwJIaDOdJMebEFPA+t98EvjuljDx4hNulAGwF6KIjtwI5jgQ==",
+      "license": "MIT"
     },
     "node_modules/three-instanced-uniforms-mesh": {
       "version": "0.52.4",
@@ -7986,9 +8533,9 @@
       }
     },
     "node_modules/three-mesh-bvh": {
-      "version": "0.9.4",
-      "resolved": "https://registry.npmjs.org/three-mesh-bvh/-/three-mesh-bvh-0.9.4.tgz",
-      "integrity": "sha512-+y6xLS6k5LWkNNhYsTgKXBC2D9r/z0swiehVHYhZZ8AOhaKDRCWKsN94ctV5Xy7xA4Xbnv4LKYzf7epRLPT6oQ==",
+      "version": "0.9.10",
+      "resolved": "https://registry.npmjs.org/three-mesh-bvh/-/three-mesh-bvh-0.9.10.tgz",
+      "integrity": "sha512-UOlTgPIeqUURcwaG8knxvBaruwZlC4X3/WSHEFO7rYvMVv/YNUrkfFEszvfj36pXV88dCHoHNnIp0PifkirnTQ==",
       "license": "MIT",
       "peerDependencies": {
         "three": ">= 0.159.0"
@@ -8256,7 +8803,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -8374,7 +8920,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.0.tgz",
       "integrity": "sha512-dZwN5L1VlUBewiP6H9s2+B3e3Jg96D0vzN+Ry73sOefebhYr9f94wwkMNN/9ouoU8pV1BqA1d1zGk8928cx0rg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -8452,6 +8997,30 @@
       "license": "MIT",
       "bin": {
         "analyze": "dist/bin.js"
+      }
+    },
+    "node_modules/vite-plugin-glsl": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-glsl/-/vite-plugin-glsl-1.6.0.tgz",
+      "integrity": "sha512-3i3ZvIVb13LhTcAXEHGTOW+cNG2jbJ++XsDFyCWUpnoFN1NPXvdtC4j66pig+i0QjDnmusOK/YCpiDWizxBY0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.17.0",
+        "npm": ">= 10.8.3"
+      },
+      "peerDependencies": {
+        "@rollup/pluginutils": "^5.x",
+        "esbuild": ">= 0.25",
+        "vite": ">= 3.x"
+      },
+      "peerDependenciesMeta": {
+        "@rollup/pluginutils": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        }
       }
     },
     "node_modules/vitefu": {
@@ -8769,9 +9338,8 @@
     },
     "node_modules/zod": {
       "version": "4.2.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -18,15 +18,23 @@
     "test:ui": "vitest --ui"
   },
   "dependencies": {
+    "@ag-grid-community/client-side-row-model": "^32.3.9",
+    "@ag-grid-community/core": "^32.3.9",
+    "@ag-grid-community/styles": "^32.3.9",
     "@tanstack/svelte-query": "^5.69.0",
-    "@viamrobotics/motion-tools": "1.2.2",
+    "@threlte/core": "^8.5.16",
+    "@threlte/extras": "^9.20.1",
+    "@viamrobotics/motion-tools": "1.22.0",
     "@viamrobotics/prime-core": "0.1.5",
     "@viamrobotics/sdk": "^0.57.0",
     "@viamrobotics/svelte-sdk": "^1.0.1",
     "js-cookie": "^3.0.5",
+    "koota": "^0.6.5",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^7.10.1",
+    "runed": "^0.37.1",
+    "three": "0.183.2",
     "vitest": "^4.1.0"
   },
   "devDependencies": {
@@ -55,6 +63,7 @@
     "typescript": "^5.0.0",
     "typescript-eslint": "^8.50.0",
     "vite": "^7.3.0",
-    "vite-bundle-analyzer": "^1.3.2"
+    "vite-bundle-analyzer": "^1.3.2",
+    "vite-plugin-glsl": "^1.6.0"
   }
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,7 +6,7 @@ import { analyzer } from 'vite-bundle-analyzer'
 import glsl from 'vite-plugin-glsl'
 
 // https://vitejs.dev/config/
-export default defineConfig({
+export default defineConfig(({ mode }) => ({
   test: {
     environment: 'jsdom',
     setupFiles: ['./src/lib/__tests__/setup.ts'],
@@ -26,7 +26,9 @@ export default defineConfig({
     esbuildOptions: {
       loader: {
         '.glsl': 'text',
-        '.hdr': 'file',
+        // 'file' needs an output path that doesn't exist during the dev
+        // server's dependency pre-scan, so inline as a data URL outside prod.
+        '.hdr': mode === 'production' ? 'file' : 'dataurl',
       },
     },
   },
@@ -38,4 +40,4 @@ export default defineConfig({
   build: {
     outDir: 'dist',
   },
-})
+}))

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,6 +3,7 @@ import react from '@vitejs/plugin-react'
 import { svelte } from '@sveltejs/vite-plugin-svelte'
 import tailwindcss from '@tailwindcss/vite'
 import { analyzer } from 'vite-bundle-analyzer'
+import glsl from 'vite-plugin-glsl'
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -11,14 +12,24 @@ export default defineConfig({
     setupFiles: ['./src/lib/__tests__/setup.ts'],
     globals: true,
   },
+  assetsInclude: ['**/*.hdr'],
   plugins: [
     react(),
     svelte(),
     tailwindcss(),
+    glsl(),
     analyzer({
       analyzerMode: process.env.ANALYZE_BUNDLE ? 'server' : 'json',
     }),
   ],
+  optimizeDeps: {
+    esbuildOptions: {
+      loader: {
+        '.glsl': 'text',
+        '.hdr': 'file',
+      },
+    },
+  },
   server: {
     port: 3000,
     open: false,


### PR DESCRIPTION
## Summary

Upgrades `@viamrobotics/motion-tools` from `1.2.2` to `1.22.0`. Between these versions the package was rewritten into a three.js / threlte-based 3D snapshot viewer, so this is less a version bump than adopting a 3D rendering toolchain into the build. The integration mirrors the already-validated setup in the sibling `sanding-webapp` project.

## Testing

- `npm run build` — passes. The 3D weight lands in **lazy** chunks (`SnapshotModal` ~1.6MB, `BatchedArrow` ~1.2MB), not the main bundle, so first paint is unaffected — the viewer only downloads when a snapshot opens.
- `npm run typecheck` and `npm run lint` — pass.
- `npx vitest run` — all 53 tests pass.
- Tested with machine, old snapshots don't work. I don't have a new one to try so im inclined to release this, then rollback if it does not work. 