### PR TITLE
Support rdk:service:video stores in video store dropdown

### DIFF
--- a/.changeset/video-store-service-dropdown.md
+++ b/.changeset/video-store-service-dropdown.md
@@ -1,0 +1,7 @@
+---
+"sanding-monitoring-web-app": minor
+---
+
+Support `rdk:service:video` video stores in the video store dropdown alongside generic components (`rdk:component:generic`). The selector now constructs the SDK client that matches the selected resource's type — `VideoClient` for video services, `GenericComponentClient` for generic components — so `doCommand` routes to the correct gRPC API.
+
+This required upgrading `@viamrobotics/sdk` from `^0.57.0` to `^0.72.0`: the video service runtime client (`VideoClient`) did not exist in 0.57.0, which only shipped its type stubs.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sanding-monitoring-web-app",
-  "version": "1.20.0",
+  "version": "1.20.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sanding-monitoring-web-app",
-      "version": "1.20.0",
+      "version": "1.20.1",
       "dependencies": {
         "@ag-grid-community/client-side-row-model": "^32.3.9",
         "@ag-grid-community/core": "^32.3.9",
@@ -16,7 +16,7 @@
         "@threlte/extras": "^9.20.1",
         "@viamrobotics/motion-tools": "1.22.0",
         "@viamrobotics/prime-core": "0.1.5",
-        "@viamrobotics/sdk": "^0.57.0",
+        "@viamrobotics/sdk": "^0.72.0",
         "@viamrobotics/svelte-sdk": "^1.0.1",
         "js-cookie": "^3.0.5",
         "koota": "^0.6.5",
@@ -26,6 +26,9 @@
         "runed": "^0.37.1",
         "three": "0.183.2",
         "vitest": "^4.1.0"
+      },
+      "bin": {
+        "sanding-history": "dist-sanding-history/sanding-history.mjs"
       },
       "devDependencies": {
         "@changesets/cli": "^2.29.8",
@@ -3571,9 +3574,9 @@
       }
     },
     "node_modules/@viamrobotics/sdk": {
-      "version": "0.57.0",
-      "resolved": "https://registry.npmjs.org/@viamrobotics/sdk/-/sdk-0.57.0.tgz",
-      "integrity": "sha512-9mZS3Gf0Er7OYZDruiUR3KrWUaK29DVvLt9wj13UxtriDs7hOHGLSlT29CrCQP9L8ZPiHTmr5O3C+CZG3c42jg==",
+      "version": "0.72.0",
+      "resolved": "https://registry.npmjs.org/@viamrobotics/sdk/-/sdk-0.72.0.tgz",
+      "integrity": "sha512-nXRWH2OZ7VTBBr17bMzUVK7GPWZQGvRFN+r0BaVCwSUN8Ad4oxVu+KHxMeaP6fMPiR9cGJ+IZziovYqq5dDndA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@bufbuild/protobuf": "^1.10.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@threlte/extras": "^9.20.1",
     "@viamrobotics/motion-tools": "1.22.0",
     "@viamrobotics/prime-core": "0.1.5",
-    "@viamrobotics/sdk": "^0.57.0",
+    "@viamrobotics/sdk": "^0.72.0",
     "@viamrobotics/svelte-sdk": "^1.0.1",
     "js-cookie": "^3.0.5",
     "koota": "^0.6.5",

--- a/src/components/VideoStoreSelector.tsx
+++ b/src/components/VideoStoreSelector.tsx
@@ -2,11 +2,13 @@ import React, { useState, useEffect, useRef } from 'react'
 import * as VIAM from '@viamrobotics/sdk'
 
 import { useViamClients } from '../lib/contexts/ViamClientContext'
+import type { VideoStoreClient } from '../lib/contexts/VideoStoreContext'
+import { isVideoStoreResource } from '../lib/videoStoreUtils'
 
 const STORAGE_KEY = 'selectedVideoStore'
 
 interface VideoStoreSelectorProps {
-  onVideoStoreSelected: (client: VIAM.GenericComponentClient | null) => void
+  onVideoStoreSelected: (client: VideoStoreClient | null) => void
 }
 
 interface Resource {
@@ -50,13 +52,8 @@ const VideoStoreSelector: React.FC<VideoStoreSelectorProps> = ({
         // Get resource names from the robot client
         const resourceNames = await robotClient.resourceNames()
 
-        // Filter for components with type "component" and subtype "generic", excluding webapp
-        const filteredResources = resourceNames.filter(
-          (resource: any) =>
-            resource.type === 'component' &&
-            resource.subtype === 'generic' &&
-            resource.name !== 'webapp'
-        )
+        // Keep generic components and video services (see isVideoStoreResource)
+        const filteredResources = resourceNames.filter(isVideoStoreResource)
 
         setResources(filteredResources)
       } catch (err) {
@@ -109,10 +106,14 @@ const VideoStoreSelector: React.FC<VideoStoreSelectorProps> = ({
 
     if (resourceName && robotClient) {
       try {
-        const videoStoreClient = new VIAM.GenericComponentClient(
-          robotClient,
-          resourceName
-        )
+        // A video service (rdk:service:video) and a generic component expose
+        // the same doCommand surface but route over different gRPC APIs, so
+        // construct the client that matches the selected resource's type.
+        const selected = resources.find((r) => r.name === resourceName)
+        const videoStoreClient: VideoStoreClient =
+          selected?.type === 'service'
+            ? new VIAM.VideoClient(robotClient, resourceName)
+            : new VIAM.GenericComponentClient(robotClient, resourceName)
         onVideoStoreSelected(videoStoreClient)
         localStorage.setItem(STORAGE_KEY, resourceName)
         setError(null)

--- a/src/lib/__tests__/videoStoreUtils.test.ts
+++ b/src/lib/__tests__/videoStoreUtils.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest'
+import { isVideoStoreResource } from '../videoStoreUtils'
+
+const resource = (overrides: Partial<{ type: string; subtype: string; name: string }> = {}) => ({
+  type: 'component',
+  subtype: 'generic',
+  name: 'my-video-store',
+  ...overrides,
+})
+
+describe('isVideoStoreResource', () => {
+  it('includes generic components', () => {
+    expect(isVideoStoreResource(resource())).toBe(true)
+  })
+
+  it('includes rdk:service:video resources', () => {
+    expect(
+      isVideoStoreResource(resource({ type: 'service', subtype: 'video' }))
+    ).toBe(true)
+  })
+
+  it('excludes the webapp generic component', () => {
+    expect(isVideoStoreResource(resource({ name: 'webapp' }))).toBe(false)
+  })
+
+  it('excludes other services like vision', () => {
+    expect(
+      isVideoStoreResource(resource({ type: 'service', subtype: 'vision' }))
+    ).toBe(false)
+  })
+
+  it('excludes non-generic components like cameras', () => {
+    expect(
+      isVideoStoreResource(resource({ type: 'component', subtype: 'camera' }))
+    ).toBe(false)
+  })
+})

--- a/src/lib/contexts/VideoStoreContext.tsx
+++ b/src/lib/contexts/VideoStoreContext.tsx
@@ -1,9 +1,17 @@
 import { createContext, useContext, useState, ReactNode } from 'react'
 import * as VIAM from '@viamrobotics/sdk'
 
+/**
+ * A video store may be backed by either a generic component
+ * (`rdk:component:generic`) or a video service (`rdk:service:video`). Each has
+ * its own SDK client routing to the matching gRPC API, but both expose the only
+ * members we use here — `name` and `doCommand` — so we keep both in the union.
+ */
+export type VideoStoreClient = VIAM.GenericComponentClient | VIAM.VideoClient
+
 interface VideoStoreContextType {
-  videoStoreClient: VIAM.GenericComponentClient | null
-  setVideoStoreClient: (client: VIAM.GenericComponentClient | null) => void
+  videoStoreClient: VideoStoreClient | null
+  setVideoStoreClient: (client: VideoStoreClient | null) => void
 }
 
 const VideoStoreContext = createContext<VideoStoreContextType | undefined>(
@@ -12,7 +20,7 @@ const VideoStoreContext = createContext<VideoStoreContextType | undefined>(
 
 export function VideoStoreProvider({ children }: { children: ReactNode }) {
   const [videoStoreClient, setVideoStoreClient] =
-    useState<VIAM.GenericComponentClient | null>(null)
+    useState<VideoStoreClient | null>(null)
 
   return (
     <VideoStoreContext.Provider

--- a/src/lib/videoStoreUtils.ts
+++ b/src/lib/videoStoreUtils.ts
@@ -1,0 +1,29 @@
+/**
+ * Resource shape returned by `robotClient.resourceNames()` that we care about
+ * when deciding whether a resource can act as a video store.
+ */
+interface VideoStoreCandidate {
+  type: string
+  subtype: string
+  name: string
+}
+
+/**
+ * Returns true if a robot resource should appear in the video store dropdown.
+ *
+ * Two kinds of resources qualify:
+ *  - Generic components (`rdk:component:generic`), excluding this app's own
+ *    `webapp` generic component.
+ *  - Video services (`rdk:service:video`).
+ */
+export function isVideoStoreResource(resource: VideoStoreCandidate): boolean {
+  const isGenericComponent =
+    resource.type === 'component' &&
+    resource.subtype === 'generic' &&
+    resource.name !== 'webapp'
+
+  const isVideoService =
+    resource.type === 'service' && resource.subtype === 'video'
+
+  return isGenericComponent || isVideoService
+}

--- a/src/lib/videoUtils.ts
+++ b/src/lib/videoUtils.ts
@@ -1,5 +1,6 @@
 import * as VIAM from '@viamrobotics/sdk'
 import { Step } from './types'
+import type { VideoStoreClient } from './contexts/VideoStoreContext'
 import { VIDEO_UPLOAD_PATH } from './constants'
 import { BinaryDataFile } from './BinaryDataFile'
 
@@ -118,7 +119,7 @@ const getVideoTimeWithBuffer = (date: Date, isStart: boolean): Date => {
 }
 
 export const generateVideo = async (
-  videoStoreClient: VIAM.GenericComponentClient,
+  videoStoreClient: VideoStoreClient,
   step: Step,
   last30s: boolean = false
 ) => {


### PR DESCRIPTION
The video store dropdown only listed generic components (`rdk:component:generic`), so machines whose video store is registered as a `rdk:service:video` service couldn't be selected. This PR fixes that and I also bumped the viam-sdk to get the video service client. 

Manually tested on a machine w/ video service and was able to generate videos succesfully. 