### PR TITLE
Fix utc day header alignment

### DIFF
--- a/.changeset/lovely-bugs-warn.md
+++ b/.changeset/lovely-bugs-warn.md
@@ -1,0 +1,5 @@
+---
+'sanding-monitoring-web-app': patch
+---
+
+Group passes by local calendar day instead of UTC

--- a/src/lib/__tests__/passUtils.test.ts
+++ b/src/lib/__tests__/passUtils.test.ts
@@ -4,6 +4,7 @@ import {
   getExecutionTimeMs,
   getPassStatusLabel,
   getStepVideos,
+  localDayKey,
 } from '../passUtils'
 import type { Pass, Step } from '../types'
 
@@ -80,6 +81,18 @@ describe('getPassStatusLabel', () => {
   it('falls back to success flag when current_state is absent', () => {
     expect(getPassStatusLabel(withState(undefined, true), false)).toBe('Success')
     expect(getPassStatusLabel(withState(undefined, false), false)).toBe('Failed')
+  })
+})
+
+describe('localDayKey', () => {
+  it('returns the local Y-M-D, not UTC', () => {
+    const d = new Date(2026, 6, 12, 22, 0, 0)
+    expect(localDayKey(d)).toBe('2026-07-12')
+  })
+
+  it('zero-pads month and day', () => {
+    const d = new Date(2026, 0, 3, 0, 0, 0)
+    expect(localDayKey(d)).toBe('2026-01-03')
   })
 })
 

--- a/src/lib/contexts/PaginationContext.tsx
+++ b/src/lib/contexts/PaginationContext.tsx
@@ -8,6 +8,7 @@ import {
 } from 'react'
 import { usePass } from './PassContext'
 import { Pass } from '../types'
+import { localDayKey } from '../passUtils'
 export const DAYS_PER_PAGE = 7
 
 interface PaginationContextType {
@@ -38,8 +39,7 @@ export function PaginationProvider({ children }: { children: ReactNode }) {
 
   const groupedPasses = useMemo(() => {
     return currentPassSummaries.reduce((acc: Record<string, Pass[]>, pass) => {
-      // Use a consistent date key (YYYY-MM-DD)
-      const dateKey = pass.start.toISOString().split('T')[0]
+      const dateKey = localDayKey(pass.start)
       if (!acc[dateKey]) {
         acc[dateKey] = []
       }

--- a/src/lib/contexts/PassContext.tsx
+++ b/src/lib/contexts/PassContext.tsx
@@ -8,6 +8,7 @@ import {
 import { Pass, PassNote, PassDiagnosis } from '../types'
 import { useViamClients } from './ViamClientContext'
 import { getPassMetadataManager } from '../passMetadataManager'
+import { localDayKey } from '../passUtils'
 import {
   PASS_QUERY_BATCH_SIZE,
   buildPassSummaryPipeline,
@@ -165,8 +166,7 @@ export function PassProvider({ children }: { children: ReactNode }) {
   useEffect(() => {
     const groupedByDay = passSummaries.reduce(
       (acc: Record<string, Pass[]>, pass) => {
-        // Use a consistent date key (YYYY-MM-DD)
-        const dateKey = pass.start.toISOString().split('T')[0]
+        const dateKey = localDayKey(pass.start)
         if (!acc[dateKey]) {
           acc[dateKey] = []
         }

--- a/src/lib/dayAggregates.ts
+++ b/src/lib/dayAggregates.ts
@@ -1,5 +1,5 @@
 import { Pass, PassDiagnosis } from './types'
-import { isInProgress } from './passUtils'
+import { isInProgress, localDayKey } from './passUtils'
 
 export interface DayAggregateData {
   totalFactoryTime: number
@@ -13,13 +13,14 @@ export interface DayAggregateData {
 }
 
 /**
- * Groups passes by calendar day, keyed YYYY-MM-DD (UTC) from each pass's start.
+ * Groups passes by local calendar day, keyed YYYY-MM-DD from each pass's start.
+ * Local (not UTC) so headers align with the local times shown in each row.
  * Insertion order follows the input order, so a newest-first input yields
  * newest-first days.
  */
 export function groupPassesByDay(passes: Pass[]): Record<string, Pass[]> {
   return passes.reduce((acc: Record<string, Pass[]>, pass) => {
-    const dateKey = pass.start.toISOString().split('T')[0]
+    const dateKey = localDayKey(pass.start)
     if (!acc[dateKey]) {
       acc[dateKey] = []
     }

--- a/src/lib/dayAggregates.ts
+++ b/src/lib/dayAggregates.ts
@@ -12,12 +12,6 @@ export interface DayAggregateData {
   causeCounts: Map<string, number>
 }
 
-/**
- * Groups passes by local calendar day, keyed YYYY-MM-DD from each pass's start.
- * Local (not UTC) so headers align with the local times shown in each row.
- * Insertion order follows the input order, so a newest-first input yields
- * newest-first days.
- */
 export function groupPassesByDay(passes: Pass[]): Record<string, Pass[]> {
   return passes.reduce((acc: Record<string, Pass[]>, pass) => {
     const dateKey = localDayKey(pass.start)

--- a/src/lib/passUtils.ts
+++ b/src/lib/passUtils.ts
@@ -145,6 +145,13 @@ export const formatSelectedZones = (
   return zoneNumbers.length > 0 ? zoneNumbers.join(', ') : '—'
 }
 
+export const localDayKey = (d: Date): string => {
+  const y = d.getFullYear()
+  const m = String(d.getMonth() + 1).padStart(2, '0')
+  const day = String(d.getDate()).padStart(2, '0')
+  return `${y}-${m}-${day}`
+}
+
 // Compute total execution time (ms) for a pass by summing 'executing' steps
 export const getExecutionTimeMs = (pass: Pass): number => {
   if (!pass.steps || pass.steps.length === 0) return 0


### PR DESCRIPTION
## Description

Day headers grouped by UTC date, rows render local time. In non-UTC zones, a pass could show under the wrong day's header

Switch grouping to local Y-M-D

## Testing

Tested locally against nj2 - didn't see observe any differences
 
Prod: 
<img width="2551" height="1066" alt="Screenshot 2026-07-13 at 10 56 49 AM" src="https://github.com/user-attachments/assets/6707dfc3-80ee-4276-abd4-5078550295cc" />

Local: 
<img width="2547" height="1080" alt="Screenshot 2026-07-13 at 10 57 48 AM" src="https://github.com/user-attachments/assets/2791e08b-efb7-4f8f-bd39-4a157ee11c18" />

## Mental Checklist

- [ ] I used tailwind styling
- [ ] I split my code into components where possible
- [ ] I used contexts instead of drilling props down the component tree
- [ ] I deployed the change to my personal module [link]() (or N/A if change is very small)
