### PR TITLE
Tighten table columns

### DIFF
--- a/.changeset/puny-months-beam.md
+++ b/.changeset/puny-months-beam.md
@@ -1,0 +1,5 @@
+---
+'sanding-monitoring-web-app': patch
+---
+
+Tighten history table columns

--- a/src/components/HistoryTable/CollapsedRow.tsx
+++ b/src/components/HistoryTable/CollapsedRow.tsx
@@ -1,4 +1,4 @@
-import { formatDurationToMinutesSeconds } from '../../lib/videoUtils'
+import { formatDurationMsText } from '../../lib/videoUtils'
 import {
   formatSelectedZones,
   getExecutionTimeMs,
@@ -14,6 +14,19 @@ interface CollapsedRowProps {
   isExpanded: boolean
   toggleRowExpansion: () => void
   pieceColor?: PieceColor
+}
+
+const formatTimeRange = (start: Date, end: Date | null): string => {
+  const hm = (d: Date) => {
+    const h = d.getHours() % 12 || 12
+    const m = String(d.getMinutes()).padStart(2, '0')
+    return `${h}:${m}`
+  }
+  const period = (d: Date) => (d.getHours() >= 12 ? 'PM' : 'AM')
+  if (!end) return `${hm(start)} ${period(start)}`
+  return period(start) === period(end)
+    ? `${hm(start)} – ${hm(end)} ${period(end)}`
+    : `${hm(start)} ${period(start)} – ${hm(end)} ${period(end)}`
 }
 
 export const CollapsedRow = ({
@@ -54,7 +67,6 @@ export const CollapsedRow = ({
           ▶
         </span>
       </td>
-      <td className="text-zinc-700">{pass.start.toLocaleDateString()}</td>
       <td className="text-zinc-700 text-xs">
         {pass.pass_id ? (
           <div className="flex items-center gap-1">
@@ -209,15 +221,14 @@ export const CollapsedRow = ({
       <td>
         <StatusBadge pass={pass} isIncomplete={isIncomplete} />
       </td>
-      <td className="text-zinc-700">{pass.start.toLocaleTimeString()}</td>
       <td className="text-zinc-700">
-        {isInProgress(pass) ? '—' : pass.end.toLocaleTimeString()}
+        {formatTimeRange(pass.start, isInProgress(pass) ? null : pass.end)}
       </td>
       <td className="text-zinc-700">
-        {isInProgress(pass) ? '—' : formatDurationToMinutesSeconds(pass.start, pass.end)}
+        {isInProgress(pass) ? '—' : formatDurationMsText(pass.end.getTime() - pass.start.getTime())}
       </td>
       <td className="text-zinc-700">
-        {isInProgress(pass) ? '—' : formatDurationToMinutesSeconds(new Date(0), new Date(execMs))}
+        {isInProgress(pass) ? '—' : formatDurationMsText(execMs)}
       </td>
       <td className="text-zinc-700">
         {pass.pass_mode ? (
@@ -229,7 +240,7 @@ export const CollapsedRow = ({
         )}
       </td>
       <td className="text-zinc-700">
-        {pass.steps ? `${pass.steps.length} steps` : '—'}
+        {pass.steps ? pass.steps.length : '—'}
       </td>
       <td className="text-zinc-700">{formatSelectedZones(pass.selected_zones)}</td>
       <td className="text-zinc-700">

--- a/src/components/HistoryTable/DaySummaryHeader.tsx
+++ b/src/components/HistoryTable/DaySummaryHeader.tsx
@@ -11,7 +11,7 @@ interface DaySummaryHeaderProps {
 
 export const DaySummaryHeader: React.FC<DaySummaryHeaderProps> = ({
   data,
-  colSpan = 14,
+  colSpan = 12,
 }) => {
   const {
     totalFactoryTime,

--- a/src/components/HistoryTable/Row.tsx
+++ b/src/components/HistoryTable/Row.tsx
@@ -119,7 +119,7 @@ const Row = ({ globalIndex, pieceColor }: RowProps) => {
       />
       {isExpanded && (
         <tr className="expanded-content">
-          <td colSpan={14}>
+          <td colSpan={12}>
             <div className="pass-details">
               {/* Build information section moved inside expanded row */}
               <RenderIf condition={pass.build_info !== undefined}>

--- a/src/components/HistoryTable/index.tsx
+++ b/src/components/HistoryTable/index.tsx
@@ -36,18 +36,16 @@ const HistoryTable: React.FC = () => {
         <thead>
           <tr>
             <th className="w-5"></th>
-            <th>Day</th>
             <th>Pass ID</th>
             <th>Piece ID</th>
             <th>Status</th>
-            <th>Start time</th>
-            <th>End time</th>
-            <th>Total duration</th>
-            <th>Execution time</th>
+            <th>Start – end</th>
+            <th>Duration</th>
+            <th>Execution</th>
             <th>Mode</th>
             <th>Steps</th>
-            <th>Selected zones</th>
-            <th>Selected rounds</th>
+            <th>Zones</th>
+            <th>Rounds</th>
             <th>Error</th>
           </tr>
         </thead>
@@ -55,7 +53,7 @@ const HistoryTable: React.FC = () => {
           {Object.entries(groupedPasses).map(([dateKey, passes], dayIndex) => {
             return (
               <React.Fragment key={dateKey}>
-                <DaySummaryHeader data={dayAggregates[dateKey]} colSpan={14} />
+                <DaySummaryHeader data={dayAggregates[dateKey]} colSpan={12} />
                 {passes.map((pass: Pass, passIndex: number) => {
                   const globalIndex = `${dayIndex}-${passIndex}`
                   return (
@@ -64,7 +62,7 @@ const HistoryTable: React.FC = () => {
                         <Suspense
                           fallback={
                             <tr>
-                              <td colSpan={14}>Loading...</td>
+                              <td colSpan={12}>Loading...</td>
                             </tr>
                           }
                         >


### PR DESCRIPTION
## Description

- Merge Start time + End time → one Start – end column, HH:MM. Dedupes AM/PM when both share a period; in-progress passes show only the start
- Drop the per-row Day column (already in the day header).
- Rename headers: Total duration → Duration, Execution time → Execution, Selected zones/rounds → Zones/Rounds.
- Drop seconds from Duration/Execution values, and drop the "steps" suffix from the Steps cell.
- Column count 14 → 12; colSpan updated in all 4 sites. 

## Testing
Tested locally against nj2

**Prod:**
<img width="2556" height="1403" alt="Screenshot 2026-07-13 at 11 08 07 AM" src="https://github.com/user-attachments/assets/716ccf24-3307-489b-b8a4-e3d2c577f5db" />

**Local:**
<img width="2557" height="1272" alt="Screenshot 2026-07-13 at 11 09 05 AM" src="https://github.com/user-attachments/assets/1bd0c7f5-db93-4732-be06-bf2394846b41" />

## Mental Checklist

- [ ] I used tailwind styling
- [ ] I split my code into components where possible
- [ ] I used contexts instead of drilling props down the component tree
- [ ] I deployed the change to my personal module [link]() (or N/A if change is very small)
