### PR TITLE
Combine piece identity into one column

### DIFF
--- a/.changeset/shaggy-icons-help.md
+++ b/.changeset/shaggy-icons-help.md
@@ -1,0 +1,5 @@
+---
+'sanding-monitoring-web-app': patch
+---
+
+Combine piece identity into one column

--- a/src/components/HistoryTable/CollapsedRow.tsx
+++ b/src/components/HistoryTable/CollapsedRow.tsx
@@ -156,62 +156,64 @@ export const CollapsedRow = ({
       </td>
       <td className="text-zinc-700 text-xs">
         {pass.piece_id || pass.piece_type || pass.piece_model || pass.piece_serial ? (
-          <div className="flex flex-col gap-0.5 items-start">
+          <div className="flex flex-col gap-1 items-start leading-tight">
             {(pass.piece_type || pass.piece_model) && (
-              <span className="text-zinc-700">
+              <span className="text-zinc-800">
                 {[pass.piece_type, pass.piece_model].filter(Boolean).join(' ')}
               </span>
             )}
             {pass.piece_serial && (
-              <span className="text-zinc-500">SN {pass.piece_serial}</span>
+              <span className="font-mono text-[11px] text-zinc-500">
+                SN {pass.piece_serial}
+              </span>
             )}
             {pass.piece_id && (
-          <button
-            onClick={(e) => {
-              e.stopPropagation()
-              navigator.clipboard.writeText(pass.piece_id!)
-              const btn = e.currentTarget
-              const svg = btn.querySelector('svg')
-              const textSpan = btn.querySelector('span')
-              btn.classList.add('bg-green-100')
-              if (svg) {
-                svg.innerHTML =
-                  '<path d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z" />'
-                svg.classList.remove('fill-gray-400')
-                svg.classList.add('fill-green-700')
-              }
-              if (textSpan) {
-                textSpan.classList.add('text-green-700')
-              }
-              setTimeout(() => {
-                btn.classList.remove('bg-green-100')
-                if (svg) {
-                  svg.innerHTML =
-                    '<path d="M19,21H8V7H19M19,5H8A2,2 0 0,0 6,7V21A2,2 0 0,0 8,23H19A2,2 0 0,0 21,21V7A2,2 0 0,0 19,5M16,1H4A2,2 0 0,0 2,3V17H4V3H16V1Z" />'
-                  svg.classList.remove('fill-green-700')
-                  svg.classList.add('fill-gray-400')
-                }
-                if (textSpan) {
-                  textSpan.classList.remove('text-green-700')
-                }
-              }, 1500)
-            }}
-            className={`inline-flex items-center justify-center py-1 rounded text-xs font-medium cursor-pointer border-none gap-1.5 px-2.5 transition-colors duration-150 group ${pieceColor?.bg ?? 'bg-gray-100'} ${pieceColor?.hoverBg ?? 'hover:bg-gray-200'}`}
-            title={`Copy piece ID: ${pass.piece_id}`}
-          >
-            <span
-              className={`font-mono text-[11px] ${pieceColor?.text ?? 'text-zinc-600 hover:text-zinc-700 '}`}
-            >
-              {pass.piece_id.substring(0, 8)}
-            </span>
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              viewBox="0 0 24 24"
-              className="w-3 h-3 fill-gray-400 transition-colors duration-150"
-            >
-              <path d="M19,21H8V7H19M19,5H8A2,2 0 0,0 6,7V21A2,2 0 0,0 8,23H19A2,2 0 0,0 21,21V7A2,2 0 0,0 19,5M16,1H4A2,2 0 0,0 2,3V17H4V3H16V1Z" />
-            </svg>
-          </button>
+              <button
+                onClick={(e) => {
+                  e.stopPropagation()
+                  navigator.clipboard.writeText(pass.piece_id!)
+                  const btn = e.currentTarget
+                  const svg = btn.querySelector('svg')
+                  const textSpan = btn.querySelector('span')
+                  btn.classList.add('bg-green-100')
+                  if (svg) {
+                    svg.innerHTML =
+                      '<path d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z" />'
+                    svg.classList.remove('fill-gray-400')
+                    svg.classList.add('fill-green-700')
+                  }
+                  if (textSpan) {
+                    textSpan.classList.add('text-green-700')
+                  }
+                  setTimeout(() => {
+                    btn.classList.remove('bg-green-100')
+                    if (svg) {
+                      svg.innerHTML =
+                        '<path d="M19,21H8V7H19M19,5H8A2,2 0 0,0 6,7V21A2,2 0 0,0 8,23H19A2,2 0 0,0 21,21V7A2,2 0 0,0 19,5M16,1H4A2,2 0 0,0 2,3V17H4V3H16V1Z" />'
+                      svg.classList.remove('fill-green-700')
+                      svg.classList.add('fill-gray-400')
+                    }
+                    if (textSpan) {
+                      textSpan.classList.remove('text-green-700')
+                    }
+                  }, 1500)
+                }}
+                className={`inline-flex items-center justify-center py-1 rounded text-xs font-medium cursor-pointer border-none gap-1.5 px-2.5 transition-colors duration-150 group ${pieceColor?.bg ?? 'bg-gray-100'} ${pieceColor?.hoverBg ?? 'hover:bg-gray-200'}`}
+                title={`Copy piece ID: ${pass.piece_id}`}
+              >
+                <span
+                  className={`font-mono text-[11px] ${pieceColor?.text ?? 'text-zinc-600 hover:text-zinc-700 '}`}
+                >
+                  {pass.piece_id.substring(0, 8)}
+                </span>
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  viewBox="0 0 24 24"
+                  className="w-3 h-3 fill-gray-400 transition-colors duration-150"
+                >
+                  <path d="M19,21H8V7H19M19,5H8A2,2 0 0,0 6,7V21A2,2 0 0,0 8,23H19A2,2 0 0,0 21,21V7A2,2 0 0,0 19,5M16,1H4A2,2 0 0,0 2,3V17H4V3H16V1Z" />
+                </svg>
+              </button>
             )}
           </div>
         ) : (

--- a/src/components/HistoryTable/CollapsedRow.tsx
+++ b/src/components/HistoryTable/CollapsedRow.tsx
@@ -155,7 +155,17 @@ export const CollapsedRow = ({
         )}
       </td>
       <td className="text-zinc-700 text-xs">
-        {pass.piece_id ? (
+        {pass.piece_id || pass.piece_type || pass.piece_model || pass.piece_serial ? (
+          <div className="flex flex-col gap-0.5 items-start">
+            {(pass.piece_type || pass.piece_model) && (
+              <span className="text-zinc-700">
+                {[pass.piece_type, pass.piece_model].filter(Boolean).join(' ')}
+              </span>
+            )}
+            {pass.piece_serial && (
+              <span className="text-zinc-500">SN {pass.piece_serial}</span>
+            )}
+            {pass.piece_id && (
           <button
             onClick={(e) => {
               e.stopPropagation()
@@ -202,6 +212,8 @@ export const CollapsedRow = ({
               <path d="M19,21H8V7H19M19,5H8A2,2 0 0,0 6,7V21A2,2 0 0,0 8,23H19A2,2 0 0,0 21,21V7A2,2 0 0,0 19,5M16,1H4A2,2 0 0,0 2,3V17H4V3H16V1Z" />
             </svg>
           </button>
+            )}
+          </div>
         ) : (
           '—'
         )}

--- a/src/components/HistoryTable/index.tsx
+++ b/src/components/HistoryTable/index.tsx
@@ -38,7 +38,7 @@ const HistoryTable: React.FC = () => {
             <th className="w-5"></th>
             <th>Day</th>
             <th>Pass ID</th>
-            <th>Piece ID</th>
+            <th>Piece</th>
             <th>Status</th>
             <th>Start time</th>
             <th>End time</th>

--- a/src/lib/passQuery.ts
+++ b/src/lib/passQuery.ts
@@ -40,6 +40,9 @@ export function processTabularDataToPasses(tabularData: any[]): Pass[] {
           ? Number(pass.selected_num_rounds)
           : undefined,
       piece_id: pass.piece_id != null ? String(pass.piece_id) : undefined,
+      piece_type: pass.piece_type != null ? String(pass.piece_type) : undefined,
+      piece_model: pass.piece_model != null ? String(pass.piece_model) : undefined,
+      piece_serial: pass.piece_serial != null ? String(pass.piece_serial) : undefined,
       version: pass.version != null ? Number(pass.version) : undefined,
       current_state:
         pass.current_state != null ? String(pass.current_state) : undefined,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -22,6 +22,9 @@ export interface Pass {
   selected_zones?: string | string[]
   selected_num_rounds?: number
   piece_id?: string
+  piece_type?: string
+  piece_model?: string
+  piece_serial?: string
   version?: number
   current_state?: string
 }


### PR DESCRIPTION
## Description

Replace the Piece ID column with a Piece column that stacks Type + Model, SN + Serial, and the copyable PieceID chip.

## Testing

Tested locally against nj2

**Prod:**
<img width="2559" height="1364" alt="Screenshot 2026-07-13 at 11 30 43 AM" src="https://github.com/user-attachments/assets/c2a82588-329d-453e-8e30-b0f7ff227c75" />


**Local:**
<img width="2551" height="1414" alt="Screenshot 2026-07-13 at 11 52 49 AM" src="https://github.com/user-attachments/assets/669b5c8c-c1b1-4ea1-9e37-a67e2ac59486" />


## Mental Checklist

- [ ] I used tailwind styling
- [ ] I split my code into components where possible
- [ ] I used contexts instead of drilling props down the component tree
- [ ] I deployed the change to my personal module [link]() (or N/A if change is very small)
